### PR TITLE
Add Legal Stuff and Privacy Policy pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,8 @@ import Rating from "./pages/rating";
 import PageNotFound from "./pages/notFound";
 import Review from "./pages/cardPage";
 import ReviewSearch from "./pages/searchForCard";
+import LegalStuff from "./pages/legalStuff";
+import PrivacyPolicy from "./pages/privacyPolicy";
 
 import { AuthProvider } from "./contexts/AuthContext";
 import { DataProvider } from "./contexts/DataContext";
@@ -21,6 +23,8 @@ export default function App() {
             <Route path="/admin" element={<AdminPanel />} />
             <Route path="/review" element={<Review />} />
             <Route path="/rating" element={<Rating />} />
+            <Route path="/legal-stuff" element={<LegalStuff />} />
+            <Route path="/privacy-policy" element={<PrivacyPolicy />} />
             <Route path="*" element={<PageNotFound />} />
           </Routes>
         </Router>

--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -19,11 +19,11 @@ const navLinks = [
   //   },
   {
     name: "Legal Stuff",
-    href: "#",
+    href: "/legal-stuff",
   },
   {
     name: "Privacy Policy",
-    href: "#",
+    href: "/privacy-policy",
   },
   {
     name: "Contact",

--- a/src/pages/legalStuff.js
+++ b/src/pages/legalStuff.js
@@ -1,7 +1,7 @@
 import React from "react";
 import TopNavbar from "../components/navbar/topNavbar";
 import Footer from "../sections/Footer";
-import { Card } from "@nextui-org/react";
+import { Card, CardHeader, CardBody, CardFooter } from "@nextui-org/react";
 
 const LegalStuff = () => {
   return (
@@ -9,8 +9,10 @@ const LegalStuff = () => {
       <TopNavbar />
       <div className="container mx-auto p-4">
         <Card>
-          <Card.Body>
+          <CardHeader>
             <h1>Legal Stuff</h1>
+          </CardHeader>
+          <CardBody>
             <p>
               At CardsClarity, we believe in transparency and clarity, especially when it comes to legal matters. This page serves as a central hub for all our important legal documents. While we're in the process of developing comprehensive documentation, we want to provide you with an overview of the key legal aspects that govern our relationship with our users, partners, and visitors.
             </p>
@@ -74,10 +76,10 @@ const LegalStuff = () => {
             <p>
               We're committed to maintaining open communication with our users and ensuring that our legal documentation is clear, accessible, and compliant with all relevant laws and regulations.
             </p>
-            <p>
-              Last updated: 08/23/2024
-            </p>
-          </Card.Body>
+          </CardBody>
+          <CardFooter>
+            <p>Last updated: 08/23/2024</p>
+          </CardFooter>
         </Card>
       </div>
       <Footer />

--- a/src/pages/legalStuff.js
+++ b/src/pages/legalStuff.js
@@ -1,5 +1,5 @@
 import React from "react";
-import TopNavbar from "../components/navbar/topNavbar";
+import TopNavbar from "../components/navbar/activeNavbar";
 import Footer from "../sections/Footer";
 import { Card, CardHeader, CardBody, CardFooter } from "@nextui-org/react";
 
@@ -16,7 +16,13 @@ const LegalStuff = () => {
             <p>
               At CardsClarity, we believe in transparency and clarity, especially when it comes to legal matters. This page serves as a central hub for all our important legal documents. While we're in the process of developing comprehensive documentation, we want to provide you with an overview of the key legal aspects that govern our relationship with our users, partners, and visitors.
             </p>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>
             <h2>For Users</h2>
+          </CardHeader>
+          <CardBody>
             <p>
               As a user of CardsClarity, the following documents are essential for understanding your rights and responsibilities:
             </p>
@@ -26,7 +32,13 @@ const LegalStuff = () => {
               <li>Cookie Policy: This policy explains how we use cookies and similar technologies on our website, and how you can manage your preferences.</li>
               <li>Acceptable Use Policy: This document sets out the permitted uses and prohibited activities when using our platform.</li>
             </ul>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>
             <h2>For Partners</h2>
+          </CardHeader>
+          <CardBody>
             <p>
               If you're considering a partnership with CardsClarity, these documents will be relevant:
             </p>
@@ -34,7 +46,13 @@ const LegalStuff = () => {
               <li>Partner Agreement: This agreement outlines the terms and conditions for our various partnership programs.</li>
               <li>Affiliate Program Terms: If you're interested in our affiliate program, this document details the rules and compensation structure.</li>
             </ul>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>
             <h2>For Everyone</h2>
+          </CardHeader>
+          <CardBody>
             <p>
               These documents apply to all visitors of our website and users of our services:
             </p>
@@ -43,7 +61,13 @@ const LegalStuff = () => {
               <li>Intellectual Property Rights: Information about our trademarks, copyrights, and how you can use our brand assets.</li>
               <li>Accessibility Statement: Our commitment to making our website and services accessible to all users.</li>
             </ul>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>
             <h2>Data Privacy and Security</h2>
+          </CardHeader>
+          <CardBody>
             <p>
               At CardsClarity, we take data privacy and security seriously. While we're finalizing our comprehensive documentation, please know that we adhere to industry-standard practices for data protection, including:
             </p>
@@ -53,11 +77,23 @@ const LegalStuff = () => {
               <li>Providing transparency about our data collection and use practices</li>
               <li>Offering users control over their personal information</li>
             </ul>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>
             <h2>Future Updates</h2>
+          </CardHeader>
+          <CardBody>
             <p>
               We're continuously working on improving and expanding our legal documentation to provide you with the most comprehensive and up-to-date information. As we develop new documents or make significant changes to existing ones, we'll update this page and notify our users accordingly.
             </p>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>
             <h2>Contact Us</h2>
+          </CardHeader>
+          <CardBody>
             <p>
               If you have any questions about our legal documents or need further clarification, please don't hesitate to contact us at:
             </p>

--- a/src/pages/legalStuff.js
+++ b/src/pages/legalStuff.js
@@ -1,75 +1,86 @@
 import React from "react";
+import TopNavbar from "../components/navbar/topNavbar";
+import Footer from "../sections/Footer";
+import { Card, Text } from "@nextui-org/react";
 
 const LegalStuff = () => {
   return (
-    <div className="legal-stuff">
-      <h1>Legal Stuff</h1>
-      <p>
-        At CardsClarity, we believe in transparency and clarity, especially when it comes to legal matters. This page serves as a central hub for all our important legal documents. While we're in the process of developing comprehensive documentation, we want to provide you with an overview of the key legal aspects that govern our relationship with our users, partners, and visitors.
-      </p>
-      <h2>For Users</h2>
-      <p>
-        As a user of CardsClarity, the following documents are essential for understanding your rights and responsibilities:
-      </p>
-      <ul>
-        <li>Terms of Service: This document outlines the rules and regulations for using our platform, including user responsibilities, content guidelines, and our service commitments.</li>
-        <li>Privacy Policy: Our privacy policy details how we collect, use, and protect your personal information, ensuring compliance with data protection laws.</li>
-        <li>Cookie Policy: This policy explains how we use cookies and similar technologies on our website, and how you can manage your preferences.</li>
-        <li>Acceptable Use Policy: This document sets out the permitted uses and prohibited activities when using our platform.</li>
-      </ul>
-      <h2>For Partners</h2>
-      <p>
-        If you're considering a partnership with CardsClarity, these documents will be relevant:
-      </p>
-      <ul>
-        <li>Partner Agreement: This agreement outlines the terms and conditions for our various partnership programs.</li>
-        <li>Affiliate Program Terms: If you're interested in our affiliate program, this document details the rules and compensation structure.</li>
-      </ul>
-      <h2>For Everyone</h2>
-      <p>
-        These documents apply to all visitors of our website and users of our services:
-      </p>
-      <ul>
-        <li>Website Terms of Use: This document governs your use of our website, regardless of whether you're a registered user.</li>
-        <li>Intellectual Property Rights: Information about our trademarks, copyrights, and how you can use our brand assets.</li>
-        <li>Accessibility Statement: Our commitment to making our website and services accessible to all users.</li>
-      </ul>
-      <h2>Data Privacy and Security</h2>
-      <p>
-        At CardsClarity, we take data privacy and security seriously. While we're finalizing our comprehensive documentation, please know that we adhere to industry-standard practices for data protection, including:
-      </p>
-      <ul>
-        <li>Implementing robust security measures to protect user data</li>
-        <li>Complying with relevant data protection regulations</li>
-        <li>Providing transparency about our data collection and use practices</li>
-        <li>Offering users control over their personal information</li>
-      </ul>
-      <h2>Future Updates</h2>
-      <p>
-        We're continuously working on improving and expanding our legal documentation to provide you with the most comprehensive and up-to-date information. As we develop new documents or make significant changes to existing ones, we'll update this page and notify our users accordingly.
-      </p>
-      <h2>Contact Us</h2>
-      <p>
-        If you have any questions about our legal documents or need further clarification, please don't hesitate to contact us at:
-      </p>
-      <p>
-        CardsClarity, Inc.
-      </p>
-      <p>
-        Email: cardsclarity@gmail.com
-      </p>
-      <p>
-        Phone: +1 (650) 4540709 - Dylan Bardsley (CEO)
-      </p>
-      <p>
-        Phone: +1 (347) 4706644 - Mark Leaf (CTO)
-      </p>
-      <p>
-        We're committed to maintaining open communication with our users and ensuring that our legal documentation is clear, accessible, and compliant with all relevant laws and regulations.
-      </p>
-      <p>
-        Last updated: 08/23/2024
-      </p>
+    <div>
+      <TopNavbar />
+      <div className="container mx-auto p-4">
+        <Card>
+          <Card.Body>
+            <Text h1>Legal Stuff</Text>
+            <Text>
+              At CardsClarity, we believe in transparency and clarity, especially when it comes to legal matters. This page serves as a central hub for all our important legal documents. While we're in the process of developing comprehensive documentation, we want to provide you with an overview of the key legal aspects that govern our relationship with our users, partners, and visitors.
+            </Text>
+            <Text h2>For Users</Text>
+            <Text>
+              As a user of CardsClarity, the following documents are essential for understanding your rights and responsibilities:
+            </Text>
+            <ul>
+              <li>Terms of Service: This document outlines the rules and regulations for using our platform, including user responsibilities, content guidelines, and our service commitments.</li>
+              <li>Privacy Policy: Our privacy policy details how we collect, use, and protect your personal information, ensuring compliance with data protection laws.</li>
+              <li>Cookie Policy: This policy explains how we use cookies and similar technologies on our website, and how you can manage your preferences.</li>
+              <li>Acceptable Use Policy: This document sets out the permitted uses and prohibited activities when using our platform.</li>
+            </ul>
+            <Text h2>For Partners</Text>
+            <Text>
+              If you're considering a partnership with CardsClarity, these documents will be relevant:
+            </Text>
+            <ul>
+              <li>Partner Agreement: This agreement outlines the terms and conditions for our various partnership programs.</li>
+              <li>Affiliate Program Terms: If you're interested in our affiliate program, this document details the rules and compensation structure.</li>
+            </ul>
+            <Text h2>For Everyone</Text>
+            <Text>
+              These documents apply to all visitors of our website and users of our services:
+            </Text>
+            <ul>
+              <li>Website Terms of Use: This document governs your use of our website, regardless of whether you're a registered user.</li>
+              <li>Intellectual Property Rights: Information about our trademarks, copyrights, and how you can use our brand assets.</li>
+              <li>Accessibility Statement: Our commitment to making our website and services accessible to all users.</li>
+            </ul>
+            <Text h2>Data Privacy and Security</Text>
+            <Text>
+              At CardsClarity, we take data privacy and security seriously. While we're finalizing our comprehensive documentation, please know that we adhere to industry-standard practices for data protection, including:
+            </Text>
+            <ul>
+              <li>Implementing robust security measures to protect user data</li>
+              <li>Complying with relevant data protection regulations</li>
+              <li>Providing transparency about our data collection and use practices</li>
+              <li>Offering users control over their personal information</li>
+            </ul>
+            <Text h2>Future Updates</Text>
+            <Text>
+              We're continuously working on improving and expanding our legal documentation to provide you with the most comprehensive and up-to-date information. As we develop new documents or make significant changes to existing ones, we'll update this page and notify our users accordingly.
+            </Text>
+            <Text h2>Contact Us</Text>
+            <Text>
+              If you have any questions about our legal documents or need further clarification, please don't hesitate to contact us at:
+            </Text>
+            <Text>
+              CardsClarity, Inc.
+            </Text>
+            <Text>
+              Email: cardsclarity@gmail.com
+            </Text>
+            <Text>
+              Phone: +1 (650) 4540709 - Dylan Bardsley (CEO)
+            </Text>
+            <Text>
+              Phone: +1 (347) 4706644 - Mark Leaf (CTO)
+            </Text>
+            <Text>
+              We're committed to maintaining open communication with our users and ensuring that our legal documentation is clear, accessible, and compliant with all relevant laws and regulations.
+            </Text>
+            <Text>
+              Last updated: 08/23/2024
+            </Text>
+          </Card.Body>
+        </Card>
+      </div>
+      <Footer />
     </div>
   );
 };

--- a/src/pages/legalStuff.js
+++ b/src/pages/legalStuff.js
@@ -1,0 +1,77 @@
+import React from "react";
+
+const LegalStuff = () => {
+  return (
+    <div className="legal-stuff">
+      <h1>Legal Stuff</h1>
+      <p>
+        At CardsClarity, we believe in transparency and clarity, especially when it comes to legal matters. This page serves as a central hub for all our important legal documents. While we're in the process of developing comprehensive documentation, we want to provide you with an overview of the key legal aspects that govern our relationship with our users, partners, and visitors.
+      </p>
+      <h2>For Users</h2>
+      <p>
+        As a user of CardsClarity, the following documents are essential for understanding your rights and responsibilities:
+      </p>
+      <ul>
+        <li>Terms of Service: This document outlines the rules and regulations for using our platform, including user responsibilities, content guidelines, and our service commitments.</li>
+        <li>Privacy Policy: Our privacy policy details how we collect, use, and protect your personal information, ensuring compliance with data protection laws.</li>
+        <li>Cookie Policy: This policy explains how we use cookies and similar technologies on our website, and how you can manage your preferences.</li>
+        <li>Acceptable Use Policy: This document sets out the permitted uses and prohibited activities when using our platform.</li>
+      </ul>
+      <h2>For Partners</h2>
+      <p>
+        If you're considering a partnership with CardsClarity, these documents will be relevant:
+      </p>
+      <ul>
+        <li>Partner Agreement: This agreement outlines the terms and conditions for our various partnership programs.</li>
+        <li>Affiliate Program Terms: If you're interested in our affiliate program, this document details the rules and compensation structure.</li>
+      </ul>
+      <h2>For Everyone</h2>
+      <p>
+        These documents apply to all visitors of our website and users of our services:
+      </p>
+      <ul>
+        <li>Website Terms of Use: This document governs your use of our website, regardless of whether you're a registered user.</li>
+        <li>Intellectual Property Rights: Information about our trademarks, copyrights, and how you can use our brand assets.</li>
+        <li>Accessibility Statement: Our commitment to making our website and services accessible to all users.</li>
+      </ul>
+      <h2>Data Privacy and Security</h2>
+      <p>
+        At CardsClarity, we take data privacy and security seriously. While we're finalizing our comprehensive documentation, please know that we adhere to industry-standard practices for data protection, including:
+      </p>
+      <ul>
+        <li>Implementing robust security measures to protect user data</li>
+        <li>Complying with relevant data protection regulations</li>
+        <li>Providing transparency about our data collection and use practices</li>
+        <li>Offering users control over their personal information</li>
+      </ul>
+      <h2>Future Updates</h2>
+      <p>
+        We're continuously working on improving and expanding our legal documentation to provide you with the most comprehensive and up-to-date information. As we develop new documents or make significant changes to existing ones, we'll update this page and notify our users accordingly.
+      </p>
+      <h2>Contact Us</h2>
+      <p>
+        If you have any questions about our legal documents or need further clarification, please don't hesitate to contact us at:
+      </p>
+      <p>
+        CardsClarity, Inc.
+      </p>
+      <p>
+        Email: cardsclarity@gmail.com
+      </p>
+      <p>
+        Phone: +1 (650) 4540709 - Dylan Bardsley (CEO)
+      </p>
+      <p>
+        Phone: +1 (347) 4706644 - Mark Leaf (CTO)
+      </p>
+      <p>
+        We're committed to maintaining open communication with our users and ensuring that our legal documentation is clear, accessible, and compliant with all relevant laws and regulations.
+      </p>
+      <p>
+        Last updated: 08/23/2024
+      </p>
+    </div>
+  );
+};
+
+export default LegalStuff;

--- a/src/pages/legalStuff.js
+++ b/src/pages/legalStuff.js
@@ -1,7 +1,7 @@
 import React from "react";
 import TopNavbar from "../components/navbar/topNavbar";
 import Footer from "../sections/Footer";
-import { Card, Text } from "@nextui-org/react";
+import { Card } from "@nextui-org/react";
 
 const LegalStuff = () => {
   return (
@@ -10,73 +10,73 @@ const LegalStuff = () => {
       <div className="container mx-auto p-4">
         <Card>
           <Card.Body>
-            <Text h1>Legal Stuff</Text>
-            <Text>
+            <h1>Legal Stuff</h1>
+            <p>
               At CardsClarity, we believe in transparency and clarity, especially when it comes to legal matters. This page serves as a central hub for all our important legal documents. While we're in the process of developing comprehensive documentation, we want to provide you with an overview of the key legal aspects that govern our relationship with our users, partners, and visitors.
-            </Text>
-            <Text h2>For Users</Text>
-            <Text>
+            </p>
+            <h2>For Users</h2>
+            <p>
               As a user of CardsClarity, the following documents are essential for understanding your rights and responsibilities:
-            </Text>
+            </p>
             <ul>
               <li>Terms of Service: This document outlines the rules and regulations for using our platform, including user responsibilities, content guidelines, and our service commitments.</li>
               <li>Privacy Policy: Our privacy policy details how we collect, use, and protect your personal information, ensuring compliance with data protection laws.</li>
               <li>Cookie Policy: This policy explains how we use cookies and similar technologies on our website, and how you can manage your preferences.</li>
               <li>Acceptable Use Policy: This document sets out the permitted uses and prohibited activities when using our platform.</li>
             </ul>
-            <Text h2>For Partners</Text>
-            <Text>
+            <h2>For Partners</h2>
+            <p>
               If you're considering a partnership with CardsClarity, these documents will be relevant:
-            </Text>
+            </p>
             <ul>
               <li>Partner Agreement: This agreement outlines the terms and conditions for our various partnership programs.</li>
               <li>Affiliate Program Terms: If you're interested in our affiliate program, this document details the rules and compensation structure.</li>
             </ul>
-            <Text h2>For Everyone</Text>
-            <Text>
+            <h2>For Everyone</h2>
+            <p>
               These documents apply to all visitors of our website and users of our services:
-            </Text>
+            </p>
             <ul>
               <li>Website Terms of Use: This document governs your use of our website, regardless of whether you're a registered user.</li>
               <li>Intellectual Property Rights: Information about our trademarks, copyrights, and how you can use our brand assets.</li>
               <li>Accessibility Statement: Our commitment to making our website and services accessible to all users.</li>
             </ul>
-            <Text h2>Data Privacy and Security</Text>
-            <Text>
+            <h2>Data Privacy and Security</h2>
+            <p>
               At CardsClarity, we take data privacy and security seriously. While we're finalizing our comprehensive documentation, please know that we adhere to industry-standard practices for data protection, including:
-            </Text>
+            </p>
             <ul>
               <li>Implementing robust security measures to protect user data</li>
               <li>Complying with relevant data protection regulations</li>
               <li>Providing transparency about our data collection and use practices</li>
               <li>Offering users control over their personal information</li>
             </ul>
-            <Text h2>Future Updates</Text>
-            <Text>
+            <h2>Future Updates</h2>
+            <p>
               We're continuously working on improving and expanding our legal documentation to provide you with the most comprehensive and up-to-date information. As we develop new documents or make significant changes to existing ones, we'll update this page and notify our users accordingly.
-            </Text>
-            <Text h2>Contact Us</Text>
-            <Text>
+            </p>
+            <h2>Contact Us</h2>
+            <p>
               If you have any questions about our legal documents or need further clarification, please don't hesitate to contact us at:
-            </Text>
-            <Text>
+            </p>
+            <p>
               CardsClarity, Inc.
-            </Text>
-            <Text>
+            </p>
+            <p>
               Email: cardsclarity@gmail.com
-            </Text>
-            <Text>
+            </p>
+            <p>
               Phone: +1 (650) 4540709 - Dylan Bardsley (CEO)
-            </Text>
-            <Text>
+            </p>
+            <p>
               Phone: +1 (347) 4706644 - Mark Leaf (CTO)
-            </Text>
-            <Text>
+            </p>
+            <p>
               We're committed to maintaining open communication with our users and ensuring that our legal documentation is clear, accessible, and compliant with all relevant laws and regulations.
-            </Text>
-            <Text>
+            </p>
+            <p>
               Last updated: 08/23/2024
-            </Text>
+            </p>
           </Card.Body>
         </Card>
       </div>

--- a/src/pages/legalStuff.js
+++ b/src/pages/legalStuff.js
@@ -1,20 +1,25 @@
 import React from "react";
 import TopNavbar from "../components/navbar/activeNavbar";
-import Footer from "../sections/Footer";
+import Footer from "../components/footer/footer";
 import { Card, CardHeader, CardBody, CardFooter } from "@nextui-org/react";
 
 const LegalStuff = () => {
   return (
     <div>
       <TopNavbar />
-      <div className="container mx-auto p-4">
+      <div className="container mx-auto p-4 space-y-4">
         <Card>
           <CardHeader>
             <h1>Legal Stuff</h1>
           </CardHeader>
           <CardBody>
             <p>
-              At CardsClarity, we believe in transparency and clarity, especially when it comes to legal matters. This page serves as a central hub for all our important legal documents. While we're in the process of developing comprehensive documentation, we want to provide you with an overview of the key legal aspects that govern our relationship with our users, partners, and visitors.
+              At CardsClarity, we believe in transparency and clarity,
+              especially when it comes to legal matters. This page serves as a
+              central hub for all our important legal documents. While we're in
+              the process of developing comprehensive documentation, we want to
+              provide you with an overview of the key legal aspects that govern
+              our relationship with our users, partners, and visitors.
             </p>
           </CardBody>
         </Card>
@@ -24,13 +29,30 @@ const LegalStuff = () => {
           </CardHeader>
           <CardBody>
             <p>
-              As a user of CardsClarity, the following documents are essential for understanding your rights and responsibilities:
+              As a user of CardsClarity, the following documents are essential
+              for understanding your rights and responsibilities:
             </p>
             <ul>
-              <li>Terms of Service: This document outlines the rules and regulations for using our platform, including user responsibilities, content guidelines, and our service commitments.</li>
-              <li>Privacy Policy: Our privacy policy details how we collect, use, and protect your personal information, ensuring compliance with data protection laws.</li>
-              <li>Cookie Policy: This policy explains how we use cookies and similar technologies on our website, and how you can manage your preferences.</li>
-              <li>Acceptable Use Policy: This document sets out the permitted uses and prohibited activities when using our platform.</li>
+              <li>
+                Terms of Service: This document outlines the rules and
+                regulations for using our platform, including user
+                responsibilities, content guidelines, and our service
+                commitments.
+              </li>
+              <li>
+                Privacy Policy: Our privacy policy details how we collect, use,
+                and protect your personal information, ensuring compliance with
+                data protection laws.
+              </li>
+              <li>
+                Cookie Policy: This policy explains how we use cookies and
+                similar technologies on our website, and how you can manage your
+                preferences.
+              </li>
+              <li>
+                Acceptable Use Policy: This document sets out the permitted uses
+                and prohibited activities when using our platform.
+              </li>
             </ul>
           </CardBody>
         </Card>
@@ -40,11 +62,19 @@ const LegalStuff = () => {
           </CardHeader>
           <CardBody>
             <p>
-              If you're considering a partnership with CardsClarity, these documents will be relevant:
+              If you're considering a partnership with CardsClarity, these
+              documents will be relevant:
             </p>
             <ul>
-              <li>Partner Agreement: This agreement outlines the terms and conditions for our various partnership programs.</li>
-              <li>Affiliate Program Terms: If you're interested in our affiliate program, this document details the rules and compensation structure.</li>
+              <li>
+                Partner Agreement: This agreement outlines the terms and
+                conditions for our various partnership programs.
+              </li>
+              <li>
+                Affiliate Program Terms: If you're interested in our affiliate
+                program, this document details the rules and compensation
+                structure.
+              </li>
             </ul>
           </CardBody>
         </Card>
@@ -54,12 +84,22 @@ const LegalStuff = () => {
           </CardHeader>
           <CardBody>
             <p>
-              These documents apply to all visitors of our website and users of our services:
+              These documents apply to all visitors of our website and users of
+              our services:
             </p>
             <ul>
-              <li>Website Terms of Use: This document governs your use of our website, regardless of whether you're a registered user.</li>
-              <li>Intellectual Property Rights: Information about our trademarks, copyrights, and how you can use our brand assets.</li>
-              <li>Accessibility Statement: Our commitment to making our website and services accessible to all users.</li>
+              <li>
+                Website Terms of Use: This document governs your use of our
+                website, regardless of whether you're a registered user.
+              </li>
+              <li>
+                Intellectual Property Rights: Information about our trademarks,
+                copyrights, and how you can use our brand assets.
+              </li>
+              <li>
+                Accessibility Statement: Our commitment to making our website
+                and services accessible to all users.
+              </li>
             </ul>
           </CardBody>
         </Card>
@@ -69,12 +109,20 @@ const LegalStuff = () => {
           </CardHeader>
           <CardBody>
             <p>
-              At CardsClarity, we take data privacy and security seriously. While we're finalizing our comprehensive documentation, please know that we adhere to industry-standard practices for data protection, including:
+              At CardsClarity, we take data privacy and security seriously.
+              While we're finalizing our comprehensive documentation, please
+              know that we adhere to industry-standard practices for data
+              protection, including:
             </p>
             <ul>
-              <li>Implementing robust security measures to protect user data</li>
+              <li>
+                Implementing robust security measures to protect user data
+              </li>
               <li>Complying with relevant data protection regulations</li>
-              <li>Providing transparency about our data collection and use practices</li>
+              <li>
+                Providing transparency about our data collection and use
+                practices
+              </li>
               <li>Offering users control over their personal information</li>
             </ul>
           </CardBody>
@@ -85,7 +133,11 @@ const LegalStuff = () => {
           </CardHeader>
           <CardBody>
             <p>
-              We're continuously working on improving and expanding our legal documentation to provide you with the most comprehensive and up-to-date information. As we develop new documents or make significant changes to existing ones, we'll update this page and notify our users accordingly.
+              We're continuously working on improving and expanding our legal
+              documentation to provide you with the most comprehensive and
+              up-to-date information. As we develop new documents or make
+              significant changes to existing ones, we'll update this page and
+              notify our users accordingly.
             </p>
           </CardBody>
         </Card>
@@ -95,22 +147,17 @@ const LegalStuff = () => {
           </CardHeader>
           <CardBody>
             <p>
-              If you have any questions about our legal documents or need further clarification, please don't hesitate to contact us at:
+              If you have any questions about our legal documents or need
+              further clarification, please don't hesitate to contact us at:
             </p>
+            <p>CardsClarity, Inc.</p>
+            <p>Email: cardsclarity@gmail.com</p>
+            <p>Phone: +1 (650) 4540709 - Dylan Bardsley (CEO)</p>
+            <p>Phone: +1 (347) 4706644 - Mark Leaf (CTO)</p>
             <p>
-              CardsClarity, Inc.
-            </p>
-            <p>
-              Email: cardsclarity@gmail.com
-            </p>
-            <p>
-              Phone: +1 (650) 4540709 - Dylan Bardsley (CEO)
-            </p>
-            <p>
-              Phone: +1 (347) 4706644 - Mark Leaf (CTO)
-            </p>
-            <p>
-              We're committed to maintaining open communication with our users and ensuring that our legal documentation is clear, accessible, and compliant with all relevant laws and regulations.
+              We're committed to maintaining open communication with our users
+              and ensuring that our legal documentation is clear, accessible,
+              and compliant with all relevant laws and regulations.
             </p>
           </CardBody>
           <CardFooter>

--- a/src/pages/privacyPolicy.js
+++ b/src/pages/privacyPolicy.js
@@ -1,7 +1,7 @@
 import React from "react";
 import TopNavbar from "../components/navbar/topNavbar";
 import Footer from "../sections/Footer";
-import { Card, Text } from "@nextui-org/react";
+import { Card } from "@nextui-org/react";
 
 const PrivacyPolicy = () => {
   return (
@@ -10,51 +10,51 @@ const PrivacyPolicy = () => {
       <div className="container mx-auto p-4">
         <Card>
           <Card.Body>
-            <Text h1>Privacy Policy</Text>
-            <Text>Last Updated: 08/20/2024</Text>
-            <Text h2>1. Introduction</Text>
-            <Text>
+            <h1>Privacy Policy</h1>
+            <p>Last Updated: 08/20/2024</p>
+            <h2>1. Introduction</h2>
+            <p>
               CardsClarity, Inc. ("CardsClarity," "we," "us," or "our") operates the website located at cardsclarity.com and related services (collectively, the "Platform"). This Terms of Service and Privacy Policy ("Agreement") governs your access to and use of the Platform.
-            </Text>
-            <Text h2>2. Acceptance of Terms</Text>
-            <Text>
+            </p>
+            <h2>2. Acceptance of Terms</h2>
+            <p>
               By accessing or using the Platform, you ("User," "you," or "your") agree to be bound by this Agreement. If you do not agree to these terms, you must not access or use the Platform.
-            </Text>
-            <Text h2>3. Age Restrictions</Text>
-            <Text>
+            </p>
+            <h2>3. Age Restrictions</h2>
+            <p>
               You must be at least 13 years old to use the Platform. If you are under 18 years old, you must have parental consent to use the Platform. We do not knowingly collect or solicit personal information from anyone under 13 or knowingly allow such persons to register for the Platform. If we become aware that we have collected personal information from a child under 13 without verification of parental consent, we will take steps to remove that information from our servers.
-            </Text>
-            <Text h2>4. User-Generated Content</Text>
-            <Text h3>4.1. User Content</Text>
-            <Text>
+            </p>
+            <h2>4. User-Generated Content</h2>
+            <h3>4.1. User Content</h3>
+            <p>
               The Platform allows Users to submit, post, and share content related to credit card products, including reviews, comments, and ratings ("User Content").
-            </Text>
-            <Text h3>4.2. Ownership and License</Text>
-            <Text>
+            </p>
+            <h3>4.2. Ownership and License</h3>
+            <p>
               You retain all ownership rights to your User Content. However, by submitting User Content to the Platform, you grant CardsClarity a worldwide, non-exclusive, royalty-free, sublicensable, and transferable license to use, reproduce, distribute, prepare derivative works of, display, and perform the User Content in connection with the Platform and CardsClarity's business operations.
-            </Text>
-            <Text h3>4.3. Representations and Warranties</Text>
-            <Text>
+            </p>
+            <h3>4.3. Representations and Warranties</h3>
+            <p>
               You represent and warrant that: (i) you own the User Content posted by you on or through the Platform or otherwise have the right to grant the license set forth in this section, and (ii) your User Content does not violate the privacy rights, publicity rights, copyrights, contract rights, intellectual property rights or any other rights of any person or entity.
-            </Text>
-            <Text h3>4.4. Prohibited Content</Text>
-            <Text>
+            </p>
+            <h3>4.4. Prohibited Content</h3>
+            <p>
               You agree not to post User Content that:
-            </Text>
+            </p>
             <ul>
               <li>Is illegal, obscene, defamatory, threatening, intimidating, harassing, hateful, racially, or ethnically offensive, or instigates or encourages conduct that would be illegal or otherwise inappropriate.</li>
               <li>Infringes any patent, trademark, trade secret, copyright, or other intellectual or proprietary right of any party.</li>
               <li>Contains software viruses or any other computer code designed to interrupt, destroy, or limit the functionality of any computer software or hardware.</li>
               <li>Impersonates any person or entity or otherwise misrepresents your affiliation with a person or entity.</li>
             </ul>
-            <Text h3>4.5. Monitoring and Removal</Text>
-            <Text>
+            <h3>4.5. Monitoring and Removal</h3>
+            <p>
               CardsClarity reserves the right, but is not obligated, to monitor, edit, or remove any User Content at our sole discretion, including content that we determine violates this Agreement or may be offensive, illegal, or violate the rights of any third party.
-            </Text>
-            <Text h3>4.6. Consequences of Posting Prohibited Content</Text>
-            <Text>
+            </p>
+            <h3>4.6. Consequences of Posting Prohibited Content</h3>
+            <p>
               If you post prohibited content, CardsClarity may, at its sole discretion:
-            </Text>
+            </p>
             <ul>
               <li>Remove the content</li>
               <li>Issue a warning</li>
@@ -62,32 +62,32 @@ const PrivacyPolicy = () => {
               <li>Ban you from the Platform</li>
               <li>Take legal action if necessary</li>
             </ul>
-            <Text h2>5. Intellectual Property Rights</Text>
-            <Text h3>5.1. CardsClarity's Intellectual Property</Text>
-            <Text>
+            <h2>5. Intellectual Property Rights</h2>
+            <h3>5.1. CardsClarity's Intellectual Property</h3>
+            <p>
               The Platform and its original content (excluding User Content), features, and functionality are owned by CardsClarity and are protected by international copyright, trademark, patent, trade secret, and other intellectual property or proprietary rights laws.
-            </Text>
-            <Text h3>5.2. User's Intellectual Property</Text>
-            <Text>
+            </p>
+            <h3>5.2. User's Intellectual Property</h3>
+            <p>
               You retain all rights to any content you submit, post or display on or through the Platform. By submitting, posting or displaying content on or through the Platform, you grant us a worldwide, non-exclusive, royalty-free license to use, reproduce, adapt, publish, translate and distribute it in any and all media.
-            </Text>
-            <Text h3>5.3. Copyright Infringement</Text>
-            <Text>
+            </p>
+            <h3>5.3. Copyright Infringement</h3>
+            <p>
               If you believe that any User Content violates your copyright, please contact us at cardsclarity@gmail.com with a detailed description of the alleged infringement. We will respond to notices of alleged copyright infringement that comply with applicable law and are properly provided to us.
-            </Text>
-            <Text h2>6. Privacy Policy</Text>
-            <Text h3>6.1. Data Collection</Text>
-            <Text>
+            </p>
+            <h2>6. Privacy Policy</h2>
+            <h3>6.1. Data Collection</h3>
+            <p>
               We collect personal information you provide during account creation and platform interaction, including email address, name, account password, username, comments, and votes.
-            </Text>
-            <Text h3>6.2. Data Usage</Text>
-            <Text>
+            </p>
+            <h3>6.2. Data Usage</h3>
+            <p>
               We use collected information to manage accounts, facilitate communication, personalize content, and improve our services.
-            </Text>
-            <Text h3>6.3. Data Security</Text>
-            <Text>
+            </p>
+            <h3>6.3. Data Security</h3>
+            <p>
               We implement industry-standard encryption protocols and security measures to protect user data from unauthorized access and potential breaches. These measures include:
-            </Text>
+            </p>
             <ul>
               <li>Secure Socket Layer (SSL) technology</li>
               <li>Regular security audits</li>
@@ -95,61 +95,61 @@ const PrivacyPolicy = () => {
               <li>Limited access to personal information on a need-to-know basis</li>
               <li>Firewalls and intrusion detection systems</li>
             </ul>
-            <Text h3>6.4. Data Aggregation</Text>
-            <Text>
+            <h3>6.4. Data Aggregation</h3>
+            <p>
               Credit card-related information displayed on the Platform is collected through secure API calls and web scraping techniques from official sources. CardsClarity does not independently verify this information and makes no representations or warranties regarding its accuracy.
-            </Text>
-            <Text h3>6.5. Cookies</Text>
-            <Text>
+            </p>
+            <h3>6.5. Cookies</h3>
+            <p>
               We use cookies strictly for authorization purposes. No other data is collected or used from cookies.
-            </Text>
-            <Text h3>6.6. Third-Party Services</Text>
-            <Text>
+            </p>
+            <h3>6.6. Third-Party Services</h3>
+            <p>
               We use the following third-party services for data processing and analytics:
-            </Text>
+            </p>
             <ul>
               <li>Google Analytics for website traffic analysis</li>
               <li>Stripe for payment processing</li>
               <li>SendGrid for email communications</li>
             </ul>
-            <Text>
+            <p>
               These services may collect and process personal information as per their own privacy policies.
-            </Text>
-            <Text h3>6.7. Data Retention</Text>
-            <Text>
+            </p>
+            <h3>6.7. Data Retention</h3>
+            <p>
               We retain user data for as long as an account is active or as needed to provide services. If you delete your account, we will delete your personal information within 30 days, except for information we are required to retain for legal or business purposes.
-            </Text>
-            <Text h3>6.8. Updates to Privacy Policy</Text>
-            <Text>
+            </p>
+            <h3>6.8. Updates to Privacy Policy</h3>
+            <p>
               We will notify users of any material changes to this Privacy Policy via email and/or a prominent notice on our Platform at least 30 days prior to the changes becoming effective.
-            </Text>
-            <Text h2>7. California Consumer Privacy Act (CCPA) Rights</Text>
-            <Text>
+            </p>
+            <h2>7. California Consumer Privacy Act (CCPA) Rights</h2>
+            <p>
               For California residents, in addition to the rights described elsewhere in this Agreement, you have the following rights under the CCPA:
-            </Text>
-            <Text h3>7.1. Right to Know</Text>
-            <Text>
+            </p>
+            <h3>7.1. Right to Know</h3>
+            <p>
               You have the right to request that we disclose certain information to you about our collection and use of your personal information over the past 12 months.
-            </Text>
-            <Text h3>7.2. Right to Delete</Text>
-            <Text>
+            </p>
+            <h3>7.2. Right to Delete</h3>
+            <p>
               You have the right to request that we delete any of your personal information that we collected from you and retained, subject to certain exceptions.
-            </Text>
-            <Text h3>7.3. Right to Opt-Out of Sale</Text>
-            <Text>
+            </p>
+            <h3>7.3. Right to Opt-Out of Sale</h3>
+            <p>
               We do not sell personal information. However, if we did, you would have the right to opt-out of the sale of your personal information.
-            </Text>
-            <Text h3>7.4. Right to Non-Discrimination</Text>
-            <Text>
+            </p>
+            <h3>7.4. Right to Non-Discrimination</h3>
+            <p>
               We will not discriminate against you for exercising any of your CCPA rights.
-            </Text>
-            <Text>
+            </p>
+            <p>
               To exercise these rights, please contact us at cardsclarity@gmail.com.
-            </Text>
-            <Text h2>8. Data Breach Notification</Text>
-            <Text>
+            </p>
+            <h2>8. Data Breach Notification</h2>
+            <p>
               In the event of a data breach that compromises your personal information, we will notify you via email within 72 hours of discovering the breach. The notification will include:
-            </Text>
+            </p>
             <ul>
               <li>A description of the nature of the breach</li>
               <li>The types of information potentially involved</li>
@@ -157,67 +157,67 @@ const PrivacyPolicy = () => {
               <li>Recommended steps you can take to protect yourself</li>
               <li>Contact information for further questions or concerns</li>
             </ul>
-            <Text h2>9. Dispute Resolution and Arbitration</Text>
-            <Text h3>9.1. Informal Resolution</Text>
-            <Text>
+            <h2>9. Dispute Resolution and Arbitration</h2>
+            <h3>9.1. Informal Resolution</h3>
+            <p>
               Before initiating any arbitration or court proceeding, you agree to first contact us at cardsclarity@gmail.com and attempt to resolve any dispute informally.
-            </Text>
-            <Text h3>9.2. Arbitration Agreement</Text>
-            <Text>
+            </p>
+            <h3>9.2. Arbitration Agreement</h3>
+            <p>
               If informal resolution is unsuccessful, any dispute, controversy, or claim arising out of or relating to this Agreement, or the breach thereof, shall be determined by arbitration administered by the American Arbitration Association in accordance with its Commercial Arbitration Rules.
-            </Text>
-            <Text h3>9.3. Arbitration Process</Text>
-            <Text>
+            </p>
+            <h3>9.3. Arbitration Process</h3>
+            <p>
               The arbitration will be conducted in the English language in United States, New York. One arbitrator will be selected in accordance with the American Arbitration Association Rules. Each party will be responsible for paying any filing, administrative, and arbitrator fees in accordance with American Arbitration Association Rules.
-            </Text>
-            <Text h3>9.4. Class Action Waiver</Text>
-            <Text>
+            </p>
+            <h3>9.4. Class Action Waiver</h3>
+            <p>
               You agree that any arbitration or proceeding shall be limited to the dispute between us and you individually. To the fullest extent permitted by law, (i) no arbitration or proceeding shall be joined with any other; (ii) there is no right or authority for any dispute to be arbitrated or resolved on a class action basis or to utilize class action procedures; and (iii) there is no right or authority for any dispute to be brought in a purported representative capacity on behalf of the general public or any other persons.
-            </Text>
-            <Text h3>9.5. Opt-Out</Text>
-            <Text>
+            </p>
+            <h3>9.5. Opt-Out</h3>
+            <p>
               You have the right to opt-out and not be bound by the arbitration and class action waiver provisions by sending written notice of your decision to opt-out to cardsclarity@gmail.com within 30 days of your first use of the Platform.
-            </Text>
-            <Text h2>10. Termination</Text>
-            <Text h3>10.1. Termination by CardsClarity</Text>
-            <Text>
+            </p>
+            <h2>10. Termination</h2>
+            <h3>10.1. Termination by CardsClarity</h3>
+            <p>
               We may terminate or suspend your account and bar access to the Platform immediately, without prior notice or liability, under our sole discretion, for any reason whatsoever and without limitation, including but not limited to a breach of this Agreement.
-            </Text>
-            <Text h3>10.2. Termination by User</Text>
-            <Text>
+            </p>
+            <h3>10.2. Termination by User</h3>
+            <p>
               You may terminate your account at any time by contacting us at cardsclarity@gmail.com.
-            </Text>
-            <Text h3>10.3. Effect of Termination</Text>
-            <Text>
+            </p>
+            <h3>10.3. Effect of Termination</h3>
+            <p>
               Upon termination, your right to use the Platform will immediately cease. If you wish to terminate your account, you may simply discontinue using the Platform.
-            </Text>
-            <Text h3>10.4. Survival of Terms</Text>
-            <Text>
+            </p>
+            <h3>10.4. Survival of Terms</h3>
+            <p>
               All provisions of this Agreement which by their nature should survive termination shall survive termination, including, without limitation, ownership provisions, warranty disclaimers, indemnity and limitations of liability.
-            </Text>
-            <Text h2>11. Changes to this Agreement</Text>
-            <Text>
+            </p>
+            <h2>11. Changes to this Agreement</h2>
+            <p>
               We reserve the right to modify this Agreement at any time. We will notify users of any material changes by posting the new Agreement on the Platform and updating the "Last Updated" date at the top of this Agreement. Your continued use of the Platform after any such changes constitutes your acceptance of the new Agreement.
-            </Text>
-            <Text h2>12. Contact Information</Text>
-            <Text>
+            </p>
+            <h2>12. Contact Information</h2>
+            <p>
               If you have any questions about this Agreement, please contact us at:
-            </Text>
-            <Text>
+            </p>
+            <p>
               CardsClarity, Inc.
-            </Text>
-            <Text>
+            </p>
+            <p>
               Email: cardsclarity@gmail.com
-            </Text>
-            <Text>
+            </p>
+            <p>
               Phone: +1 (650) 4540709 - Dylan Bardsley (CEO)
-            </Text>
-            <Text>
+            </p>
+            <p>
               Phone: +1 (347) 4706644 - Mark Leaf (CTO)
-            </Text>
-            <Text>
+            </p>
+            <p>
               By using the CardsClarity Platform, you acknowledge that you have read, understood, and agree to be bound by this Agreement.
-            </Text>
+            </p>
           </Card.Body>
         </Card>
       </div>

--- a/src/pages/privacyPolicy.js
+++ b/src/pages/privacyPolicy.js
@@ -1,7 +1,7 @@
 import React from "react";
 import TopNavbar from "../components/navbar/topNavbar";
 import Footer from "../sections/Footer";
-import { Card } from "@nextui-org/react";
+import { Card, CardHeader, CardBody, CardFooter } from "@nextui-org/react";
 
 const PrivacyPolicy = () => {
   return (
@@ -9,8 +9,10 @@ const PrivacyPolicy = () => {
       <TopNavbar />
       <div className="container mx-auto p-4">
         <Card>
-          <Card.Body>
+          <CardHeader>
             <h1>Privacy Policy</h1>
+          </CardHeader>
+          <CardBody>
             <p>Last Updated: 08/20/2024</p>
             <h2>1. Introduction</h2>
             <p>
@@ -218,7 +220,10 @@ const PrivacyPolicy = () => {
             <p>
               By using the CardsClarity Platform, you acknowledge that you have read, understood, and agree to be bound by this Agreement.
             </p>
-          </Card.Body>
+          </CardBody>
+          <CardFooter>
+            <p>Last updated: 08/20/2024</p>
+          </CardFooter>
         </Card>
       </div>
       <Footer />

--- a/src/pages/privacyPolicy.js
+++ b/src/pages/privacyPolicy.js
@@ -1,216 +1,227 @@
 import React from "react";
+import TopNavbar from "../components/navbar/topNavbar";
+import Footer from "../sections/Footer";
+import { Card, Text } from "@nextui-org/react";
 
 const PrivacyPolicy = () => {
   return (
-    <div className="privacy-policy">
-      <h1>Privacy Policy</h1>
-      <p>Last Updated: 08/20/2024</p>
-      <h2>1. Introduction</h2>
-      <p>
-        CardsClarity, Inc. ("CardsClarity," "we," "us," or "our") operates the website located at cardsclarity.com and related services (collectively, the "Platform"). This Terms of Service and Privacy Policy ("Agreement") governs your access to and use of the Platform.
-      </p>
-      <h2>2. Acceptance of Terms</h2>
-      <p>
-        By accessing or using the Platform, you ("User," "you," or "your") agree to be bound by this Agreement. If you do not agree to these terms, you must not access or use the Platform.
-      </p>
-      <h2>3. Age Restrictions</h2>
-      <p>
-        You must be at least 13 years old to use the Platform. If you are under 18 years old, you must have parental consent to use the Platform. We do not knowingly collect or solicit personal information from anyone under 13 or knowingly allow such persons to register for the Platform. If we become aware that we have collected personal information from a child under 13 without verification of parental consent, we will take steps to remove that information from our servers.
-      </p>
-      <h2>4. User-Generated Content</h2>
-      <h3>4.1. User Content</h3>
-      <p>
-        The Platform allows Users to submit, post, and share content related to credit card products, including reviews, comments, and ratings ("User Content").
-      </p>
-      <h3>4.2. Ownership and License</h3>
-      <p>
-        You retain all ownership rights to your User Content. However, by submitting User Content to the Platform, you grant CardsClarity a worldwide, non-exclusive, royalty-free, sublicensable, and transferable license to use, reproduce, distribute, prepare derivative works of, display, and perform the User Content in connection with the Platform and CardsClarity's business operations.
-      </p>
-      <h3>4.3. Representations and Warranties</h3>
-      <p>
-        You represent and warrant that: (i) you own the User Content posted by you on or through the Platform or otherwise have the right to grant the license set forth in this section, and (ii) your User Content does not violate the privacy rights, publicity rights, copyrights, contract rights, intellectual property rights or any other rights of any person or entity.
-      </p>
-      <h3>4.4. Prohibited Content</h3>
-      <p>
-        You agree not to post User Content that:
-      </p>
-      <ul>
-        <li>Is illegal, obscene, defamatory, threatening, intimidating, harassing, hateful, racially, or ethnically offensive, or instigates or encourages conduct that would be illegal or otherwise inappropriate.</li>
-        <li>Infringes any patent, trademark, trade secret, copyright, or other intellectual or proprietary right of any party.</li>
-        <li>Contains software viruses or any other computer code designed to interrupt, destroy, or limit the functionality of any computer software or hardware.</li>
-        <li>Impersonates any person or entity or otherwise misrepresents your affiliation with a person or entity.</li>
-      </ul>
-      <h3>4.5. Monitoring and Removal</h3>
-      <p>
-        CardsClarity reserves the right, but is not obligated, to monitor, edit, or remove any User Content at our sole discretion, including content that we determine violates this Agreement or may be offensive, illegal, or violate the rights of any third party.
-      </p>
-      <h3>4.6. Consequences of Posting Prohibited Content</h3>
-      <p>
-        If you post prohibited content, CardsClarity may, at its sole discretion:
-      </p>
-      <ul>
-        <li>Remove the content</li>
-        <li>Issue a warning</li>
-        <li>Temporarily or permanently suspend your account</li>
-        <li>Ban you from the Platform</li>
-        <li>Take legal action if necessary</li>
-      </ul>
-      <h2>5. Intellectual Property Rights</h2>
-      <h3>5.1. CardsClarity's Intellectual Property</h3>
-      <p>
-        The Platform and its original content (excluding User Content), features, and functionality are owned by CardsClarity and are protected by international copyright, trademark, patent, trade secret, and other intellectual property or proprietary rights laws.
-      </p>
-      <h3>5.2. User's Intellectual Property</h3>
-      <p>
-        You retain all rights to any content you submit, post or display on or through the Platform. By submitting, posting or displaying content on or through the Platform, you grant us a worldwide, non-exclusive, royalty-free license to use, reproduce, adapt, publish, translate and distribute it in any and all media.
-      </p>
-      <h3>5.3. Copyright Infringement</h3>
-      <p>
-        If you believe that any User Content violates your copyright, please contact us at cardsclarity@gmail.com with a detailed description of the alleged infringement. We will respond to notices of alleged copyright infringement that comply with applicable law and are properly provided to us.
-      </p>
-      <h2>6. Privacy Policy</h2>
-      <h3>6.1. Data Collection</h3>
-      <p>
-        We collect personal information you provide during account creation and platform interaction, including email address, name, account password, username, comments, and votes.
-      </p>
-      <h3>6.2. Data Usage</h3>
-      <p>
-        We use collected information to manage accounts, facilitate communication, personalize content, and improve our services.
-      </p>
-      <h3>6.3. Data Security</h3>
-      <p>
-        We implement industry-standard encryption protocols and security measures to protect user data from unauthorized access and potential breaches. These measures include:
-      </p>
-      <ul>
-        <li>Secure Socket Layer (SSL) technology</li>
-        <li>Regular security audits</li>
-        <li>Employee training on data protection</li>
-        <li>Limited access to personal information on a need-to-know basis</li>
-        <li>Firewalls and intrusion detection systems</li>
-      </ul>
-      <h3>6.4. Data Aggregation</h3>
-      <p>
-        Credit card-related information displayed on the Platform is collected through secure API calls and web scraping techniques from official sources. CardsClarity does not independently verify this information and makes no representations or warranties regarding its accuracy.
-      </p>
-      <h3>6.5. Cookies</h3>
-      <p>
-        We use cookies strictly for authorization purposes. No other data is collected or used from cookies.
-      </p>
-      <h3>6.6. Third-Party Services</h3>
-      <p>
-        We use the following third-party services for data processing and analytics:
-      </p>
-      <ul>
-        <li>Google Analytics for website traffic analysis</li>
-        <li>Stripe for payment processing</li>
-        <li>SendGrid for email communications</li>
-      </ul>
-      <p>
-        These services may collect and process personal information as per their own privacy policies.
-      </p>
-      <h3>6.7. Data Retention</h3>
-      <p>
-        We retain user data for as long as an account is active or as needed to provide services. If you delete your account, we will delete your personal information within 30 days, except for information we are required to retain for legal or business purposes.
-      </p>
-      <h3>6.8. Updates to Privacy Policy</h3>
-      <p>
-        We will notify users of any material changes to this Privacy Policy via email and/or a prominent notice on our Platform at least 30 days prior to the changes becoming effective.
-      </p>
-      <h2>7. California Consumer Privacy Act (CCPA) Rights</h2>
-      <p>
-        For California residents, in addition to the rights described elsewhere in this Agreement, you have the following rights under the CCPA:
-      </p>
-      <h3>7.1. Right to Know</h3>
-      <p>
-        You have the right to request that we disclose certain information to you about our collection and use of your personal information over the past 12 months.
-      </p>
-      <h3>7.2. Right to Delete</h3>
-      <p>
-        You have the right to request that we delete any of your personal information that we collected from you and retained, subject to certain exceptions.
-      </p>
-      <h3>7.3. Right to Opt-Out of Sale</h3>
-      <p>
-        We do not sell personal information. However, if we did, you would have the right to opt-out of the sale of your personal information.
-      </p>
-      <h3>7.4. Right to Non-Discrimination</h3>
-      <p>
-        We will not discriminate against you for exercising any of your CCPA rights.
-      </p>
-      <p>
-        To exercise these rights, please contact us at cardsclarity@gmail.com.
-      </p>
-      <h2>8. Data Breach Notification</h2>
-      <p>
-        In the event of a data breach that compromises your personal information, we will notify you via email within 72 hours of discovering the breach. The notification will include:
-      </p>
-      <ul>
-        <li>A description of the nature of the breach</li>
-        <li>The types of information potentially involved</li>
-        <li>Steps we are taking to investigate and mitigate the breach</li>
-        <li>Recommended steps you can take to protect yourself</li>
-        <li>Contact information for further questions or concerns</li>
-      </ul>
-      <h2>9. Dispute Resolution and Arbitration</h2>
-      <h3>9.1. Informal Resolution</h3>
-      <p>
-        Before initiating any arbitration or court proceeding, you agree to first contact us at cardsclarity@gmail.com and attempt to resolve any dispute informally.
-      </p>
-      <h3>9.2. Arbitration Agreement</h3>
-      <p>
-        If informal resolution is unsuccessful, any dispute, controversy, or claim arising out of or relating to this Agreement, or the breach thereof, shall be determined by arbitration administered by the American Arbitration Association in accordance with its Commercial Arbitration Rules.
-      </p>
-      <h3>9.3. Arbitration Process</h3>
-      <p>
-        The arbitration will be conducted in the English language in United States, New York. One arbitrator will be selected in accordance with the American Arbitration Association Rules. Each party will be responsible for paying any filing, administrative, and arbitrator fees in accordance with American Arbitration Association Rules.
-      </p>
-      <h3>9.4. Class Action Waiver</h3>
-      <p>
-        You agree that any arbitration or proceeding shall be limited to the dispute between us and you individually. To the fullest extent permitted by law, (i) no arbitration or proceeding shall be joined with any other; (ii) there is no right or authority for any dispute to be arbitrated or resolved on a class action basis or to utilize class action procedures; and (iii) there is no right or authority for any dispute to be brought in a purported representative capacity on behalf of the general public or any other persons.
-      </p>
-      <h3>9.5. Opt-Out</h3>
-      <p>
-        You have the right to opt-out and not be bound by the arbitration and class action waiver provisions by sending written notice of your decision to opt-out to cardsclarity@gmail.com within 30 days of your first use of the Platform.
-      </p>
-      <h2>10. Termination</h2>
-      <h3>10.1. Termination by CardsClarity</h3>
-      <p>
-        We may terminate or suspend your account and bar access to the Platform immediately, without prior notice or liability, under our sole discretion, for any reason whatsoever and without limitation, including but not limited to a breach of this Agreement.
-      </p>
-      <h3>10.2. Termination by User</h3>
-      <p>
-        You may terminate your account at any time by contacting us at cardsclarity@gmail.com.
-      </p>
-      <h3>10.3. Effect of Termination</h3>
-      <p>
-        Upon termination, your right to use the Platform will immediately cease. If you wish to terminate your account, you may simply discontinue using the Platform.
-      </p>
-      <h3>10.4. Survival of Terms</h3>
-      <p>
-        All provisions of this Agreement which by their nature should survive termination shall survive termination, including, without limitation, ownership provisions, warranty disclaimers, indemnity and limitations of liability.
-      </p>
-      <h2>11. Changes to this Agreement</h2>
-      <p>
-        We reserve the right to modify this Agreement at any time. We will notify users of any material changes by posting the new Agreement on the Platform and updating the "Last Updated" date at the top of this Agreement. Your continued use of the Platform after any such changes constitutes your acceptance of the new Agreement.
-      </p>
-      <h2>12. Contact Information</h2>
-      <p>
-        If you have any questions about this Agreement, please contact us at:
-      </p>
-      <p>
-        CardsClarity, Inc.
-      </p>
-      <p>
-        Email: cardsclarity@gmail.com
-      </p>
-      <p>
-        Phone: +1 (650) 4540709 - Dylan Bardsley (CEO)
-      </p>
-      <p>
-        Phone: +1 (347) 4706644 - Mark Leaf (CTO)
-      </p>
-      <p>
-        By using the CardsClarity Platform, you acknowledge that you have read, understood, and agree to be bound by this Agreement.
-      </p>
+    <div>
+      <TopNavbar />
+      <div className="container mx-auto p-4">
+        <Card>
+          <Card.Body>
+            <Text h1>Privacy Policy</Text>
+            <Text>Last Updated: 08/20/2024</Text>
+            <Text h2>1. Introduction</Text>
+            <Text>
+              CardsClarity, Inc. ("CardsClarity," "we," "us," or "our") operates the website located at cardsclarity.com and related services (collectively, the "Platform"). This Terms of Service and Privacy Policy ("Agreement") governs your access to and use of the Platform.
+            </Text>
+            <Text h2>2. Acceptance of Terms</Text>
+            <Text>
+              By accessing or using the Platform, you ("User," "you," or "your") agree to be bound by this Agreement. If you do not agree to these terms, you must not access or use the Platform.
+            </Text>
+            <Text h2>3. Age Restrictions</Text>
+            <Text>
+              You must be at least 13 years old to use the Platform. If you are under 18 years old, you must have parental consent to use the Platform. We do not knowingly collect or solicit personal information from anyone under 13 or knowingly allow such persons to register for the Platform. If we become aware that we have collected personal information from a child under 13 without verification of parental consent, we will take steps to remove that information from our servers.
+            </Text>
+            <Text h2>4. User-Generated Content</Text>
+            <Text h3>4.1. User Content</Text>
+            <Text>
+              The Platform allows Users to submit, post, and share content related to credit card products, including reviews, comments, and ratings ("User Content").
+            </Text>
+            <Text h3>4.2. Ownership and License</Text>
+            <Text>
+              You retain all ownership rights to your User Content. However, by submitting User Content to the Platform, you grant CardsClarity a worldwide, non-exclusive, royalty-free, sublicensable, and transferable license to use, reproduce, distribute, prepare derivative works of, display, and perform the User Content in connection with the Platform and CardsClarity's business operations.
+            </Text>
+            <Text h3>4.3. Representations and Warranties</Text>
+            <Text>
+              You represent and warrant that: (i) you own the User Content posted by you on or through the Platform or otherwise have the right to grant the license set forth in this section, and (ii) your User Content does not violate the privacy rights, publicity rights, copyrights, contract rights, intellectual property rights or any other rights of any person or entity.
+            </Text>
+            <Text h3>4.4. Prohibited Content</Text>
+            <Text>
+              You agree not to post User Content that:
+            </Text>
+            <ul>
+              <li>Is illegal, obscene, defamatory, threatening, intimidating, harassing, hateful, racially, or ethnically offensive, or instigates or encourages conduct that would be illegal or otherwise inappropriate.</li>
+              <li>Infringes any patent, trademark, trade secret, copyright, or other intellectual or proprietary right of any party.</li>
+              <li>Contains software viruses or any other computer code designed to interrupt, destroy, or limit the functionality of any computer software or hardware.</li>
+              <li>Impersonates any person or entity or otherwise misrepresents your affiliation with a person or entity.</li>
+            </ul>
+            <Text h3>4.5. Monitoring and Removal</Text>
+            <Text>
+              CardsClarity reserves the right, but is not obligated, to monitor, edit, or remove any User Content at our sole discretion, including content that we determine violates this Agreement or may be offensive, illegal, or violate the rights of any third party.
+            </Text>
+            <Text h3>4.6. Consequences of Posting Prohibited Content</Text>
+            <Text>
+              If you post prohibited content, CardsClarity may, at its sole discretion:
+            </Text>
+            <ul>
+              <li>Remove the content</li>
+              <li>Issue a warning</li>
+              <li>Temporarily or permanently suspend your account</li>
+              <li>Ban you from the Platform</li>
+              <li>Take legal action if necessary</li>
+            </ul>
+            <Text h2>5. Intellectual Property Rights</Text>
+            <Text h3>5.1. CardsClarity's Intellectual Property</Text>
+            <Text>
+              The Platform and its original content (excluding User Content), features, and functionality are owned by CardsClarity and are protected by international copyright, trademark, patent, trade secret, and other intellectual property or proprietary rights laws.
+            </Text>
+            <Text h3>5.2. User's Intellectual Property</Text>
+            <Text>
+              You retain all rights to any content you submit, post or display on or through the Platform. By submitting, posting or displaying content on or through the Platform, you grant us a worldwide, non-exclusive, royalty-free license to use, reproduce, adapt, publish, translate and distribute it in any and all media.
+            </Text>
+            <Text h3>5.3. Copyright Infringement</Text>
+            <Text>
+              If you believe that any User Content violates your copyright, please contact us at cardsclarity@gmail.com with a detailed description of the alleged infringement. We will respond to notices of alleged copyright infringement that comply with applicable law and are properly provided to us.
+            </Text>
+            <Text h2>6. Privacy Policy</Text>
+            <Text h3>6.1. Data Collection</Text>
+            <Text>
+              We collect personal information you provide during account creation and platform interaction, including email address, name, account password, username, comments, and votes.
+            </Text>
+            <Text h3>6.2. Data Usage</Text>
+            <Text>
+              We use collected information to manage accounts, facilitate communication, personalize content, and improve our services.
+            </Text>
+            <Text h3>6.3. Data Security</Text>
+            <Text>
+              We implement industry-standard encryption protocols and security measures to protect user data from unauthorized access and potential breaches. These measures include:
+            </Text>
+            <ul>
+              <li>Secure Socket Layer (SSL) technology</li>
+              <li>Regular security audits</li>
+              <li>Employee training on data protection</li>
+              <li>Limited access to personal information on a need-to-know basis</li>
+              <li>Firewalls and intrusion detection systems</li>
+            </ul>
+            <Text h3>6.4. Data Aggregation</Text>
+            <Text>
+              Credit card-related information displayed on the Platform is collected through secure API calls and web scraping techniques from official sources. CardsClarity does not independently verify this information and makes no representations or warranties regarding its accuracy.
+            </Text>
+            <Text h3>6.5. Cookies</Text>
+            <Text>
+              We use cookies strictly for authorization purposes. No other data is collected or used from cookies.
+            </Text>
+            <Text h3>6.6. Third-Party Services</Text>
+            <Text>
+              We use the following third-party services for data processing and analytics:
+            </Text>
+            <ul>
+              <li>Google Analytics for website traffic analysis</li>
+              <li>Stripe for payment processing</li>
+              <li>SendGrid for email communications</li>
+            </ul>
+            <Text>
+              These services may collect and process personal information as per their own privacy policies.
+            </Text>
+            <Text h3>6.7. Data Retention</Text>
+            <Text>
+              We retain user data for as long as an account is active or as needed to provide services. If you delete your account, we will delete your personal information within 30 days, except for information we are required to retain for legal or business purposes.
+            </Text>
+            <Text h3>6.8. Updates to Privacy Policy</Text>
+            <Text>
+              We will notify users of any material changes to this Privacy Policy via email and/or a prominent notice on our Platform at least 30 days prior to the changes becoming effective.
+            </Text>
+            <Text h2>7. California Consumer Privacy Act (CCPA) Rights</Text>
+            <Text>
+              For California residents, in addition to the rights described elsewhere in this Agreement, you have the following rights under the CCPA:
+            </Text>
+            <Text h3>7.1. Right to Know</Text>
+            <Text>
+              You have the right to request that we disclose certain information to you about our collection and use of your personal information over the past 12 months.
+            </Text>
+            <Text h3>7.2. Right to Delete</Text>
+            <Text>
+              You have the right to request that we delete any of your personal information that we collected from you and retained, subject to certain exceptions.
+            </Text>
+            <Text h3>7.3. Right to Opt-Out of Sale</Text>
+            <Text>
+              We do not sell personal information. However, if we did, you would have the right to opt-out of the sale of your personal information.
+            </Text>
+            <Text h3>7.4. Right to Non-Discrimination</Text>
+            <Text>
+              We will not discriminate against you for exercising any of your CCPA rights.
+            </Text>
+            <Text>
+              To exercise these rights, please contact us at cardsclarity@gmail.com.
+            </Text>
+            <Text h2>8. Data Breach Notification</Text>
+            <Text>
+              In the event of a data breach that compromises your personal information, we will notify you via email within 72 hours of discovering the breach. The notification will include:
+            </Text>
+            <ul>
+              <li>A description of the nature of the breach</li>
+              <li>The types of information potentially involved</li>
+              <li>Steps we are taking to investigate and mitigate the breach</li>
+              <li>Recommended steps you can take to protect yourself</li>
+              <li>Contact information for further questions or concerns</li>
+            </ul>
+            <Text h2>9. Dispute Resolution and Arbitration</Text>
+            <Text h3>9.1. Informal Resolution</Text>
+            <Text>
+              Before initiating any arbitration or court proceeding, you agree to first contact us at cardsclarity@gmail.com and attempt to resolve any dispute informally.
+            </Text>
+            <Text h3>9.2. Arbitration Agreement</Text>
+            <Text>
+              If informal resolution is unsuccessful, any dispute, controversy, or claim arising out of or relating to this Agreement, or the breach thereof, shall be determined by arbitration administered by the American Arbitration Association in accordance with its Commercial Arbitration Rules.
+            </Text>
+            <Text h3>9.3. Arbitration Process</Text>
+            <Text>
+              The arbitration will be conducted in the English language in United States, New York. One arbitrator will be selected in accordance with the American Arbitration Association Rules. Each party will be responsible for paying any filing, administrative, and arbitrator fees in accordance with American Arbitration Association Rules.
+            </Text>
+            <Text h3>9.4. Class Action Waiver</Text>
+            <Text>
+              You agree that any arbitration or proceeding shall be limited to the dispute between us and you individually. To the fullest extent permitted by law, (i) no arbitration or proceeding shall be joined with any other; (ii) there is no right or authority for any dispute to be arbitrated or resolved on a class action basis or to utilize class action procedures; and (iii) there is no right or authority for any dispute to be brought in a purported representative capacity on behalf of the general public or any other persons.
+            </Text>
+            <Text h3>9.5. Opt-Out</Text>
+            <Text>
+              You have the right to opt-out and not be bound by the arbitration and class action waiver provisions by sending written notice of your decision to opt-out to cardsclarity@gmail.com within 30 days of your first use of the Platform.
+            </Text>
+            <Text h2>10. Termination</Text>
+            <Text h3>10.1. Termination by CardsClarity</Text>
+            <Text>
+              We may terminate or suspend your account and bar access to the Platform immediately, without prior notice or liability, under our sole discretion, for any reason whatsoever and without limitation, including but not limited to a breach of this Agreement.
+            </Text>
+            <Text h3>10.2. Termination by User</Text>
+            <Text>
+              You may terminate your account at any time by contacting us at cardsclarity@gmail.com.
+            </Text>
+            <Text h3>10.3. Effect of Termination</Text>
+            <Text>
+              Upon termination, your right to use the Platform will immediately cease. If you wish to terminate your account, you may simply discontinue using the Platform.
+            </Text>
+            <Text h3>10.4. Survival of Terms</Text>
+            <Text>
+              All provisions of this Agreement which by their nature should survive termination shall survive termination, including, without limitation, ownership provisions, warranty disclaimers, indemnity and limitations of liability.
+            </Text>
+            <Text h2>11. Changes to this Agreement</Text>
+            <Text>
+              We reserve the right to modify this Agreement at any time. We will notify users of any material changes by posting the new Agreement on the Platform and updating the "Last Updated" date at the top of this Agreement. Your continued use of the Platform after any such changes constitutes your acceptance of the new Agreement.
+            </Text>
+            <Text h2>12. Contact Information</Text>
+            <Text>
+              If you have any questions about this Agreement, please contact us at:
+            </Text>
+            <Text>
+              CardsClarity, Inc.
+            </Text>
+            <Text>
+              Email: cardsclarity@gmail.com
+            </Text>
+            <Text>
+              Phone: +1 (650) 4540709 - Dylan Bardsley (CEO)
+            </Text>
+            <Text>
+              Phone: +1 (347) 4706644 - Mark Leaf (CTO)
+            </Text>
+            <Text>
+              By using the CardsClarity Platform, you acknowledge that you have read, understood, and agree to be bound by this Agreement.
+            </Text>
+          </Card.Body>
+        </Card>
+      </div>
+      <Footer />
     </div>
   );
 };

--- a/src/pages/privacyPolicy.js
+++ b/src/pages/privacyPolicy.js
@@ -1,5 +1,5 @@
 import React from "react";
-import TopNavbar from "../components/navbar/topNavbar";
+import TopNavbar from "../components/navbar/activeNavbar";
 import Footer from "../sections/Footer";
 import { Card, CardHeader, CardBody, CardFooter } from "@nextui-org/react";
 
@@ -18,15 +18,33 @@ const PrivacyPolicy = () => {
             <p>
               CardsClarity, Inc. ("CardsClarity," "we," "us," or "our") operates the website located at cardsclarity.com and related services (collectively, the "Platform"). This Terms of Service and Privacy Policy ("Agreement") governs your access to and use of the Platform.
             </p>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>
             <h2>2. Acceptance of Terms</h2>
+          </CardHeader>
+          <CardBody>
             <p>
               By accessing or using the Platform, you ("User," "you," or "your") agree to be bound by this Agreement. If you do not agree to these terms, you must not access or use the Platform.
             </p>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>
             <h2>3. Age Restrictions</h2>
+          </CardHeader>
+          <CardBody>
             <p>
               You must be at least 13 years old to use the Platform. If you are under 18 years old, you must have parental consent to use the Platform. We do not knowingly collect or solicit personal information from anyone under 13 or knowingly allow such persons to register for the Platform. If we become aware that we have collected personal information from a child under 13 without verification of parental consent, we will take steps to remove that information from our servers.
             </p>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>
             <h2>4. User-Generated Content</h2>
+          </CardHeader>
+          <CardBody>
             <h3>4.1. User Content</h3>
             <p>
               The Platform allows Users to submit, post, and share content related to credit card products, including reviews, comments, and ratings ("User Content").
@@ -64,7 +82,13 @@ const PrivacyPolicy = () => {
               <li>Ban you from the Platform</li>
               <li>Take legal action if necessary</li>
             </ul>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>
             <h2>5. Intellectual Property Rights</h2>
+          </CardHeader>
+          <CardBody>
             <h3>5.1. CardsClarity's Intellectual Property</h3>
             <p>
               The Platform and its original content (excluding User Content), features, and functionality are owned by CardsClarity and are protected by international copyright, trademark, patent, trade secret, and other intellectual property or proprietary rights laws.
@@ -77,7 +101,13 @@ const PrivacyPolicy = () => {
             <p>
               If you believe that any User Content violates your copyright, please contact us at cardsclarity@gmail.com with a detailed description of the alleged infringement. We will respond to notices of alleged copyright infringement that comply with applicable law and are properly provided to us.
             </p>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>
             <h2>6. Privacy Policy</h2>
+          </CardHeader>
+          <CardBody>
             <h3>6.1. Data Collection</h3>
             <p>
               We collect personal information you provide during account creation and platform interaction, including email address, name, account password, username, comments, and votes.
@@ -125,7 +155,13 @@ const PrivacyPolicy = () => {
             <p>
               We will notify users of any material changes to this Privacy Policy via email and/or a prominent notice on our Platform at least 30 days prior to the changes becoming effective.
             </p>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>
             <h2>7. California Consumer Privacy Act (CCPA) Rights</h2>
+          </CardHeader>
+          <CardBody>
             <p>
               For California residents, in addition to the rights described elsewhere in this Agreement, you have the following rights under the CCPA:
             </p>
@@ -148,7 +184,13 @@ const PrivacyPolicy = () => {
             <p>
               To exercise these rights, please contact us at cardsclarity@gmail.com.
             </p>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>
             <h2>8. Data Breach Notification</h2>
+          </CardHeader>
+          <CardBody>
             <p>
               In the event of a data breach that compromises your personal information, we will notify you via email within 72 hours of discovering the breach. The notification will include:
             </p>
@@ -159,7 +201,13 @@ const PrivacyPolicy = () => {
               <li>Recommended steps you can take to protect yourself</li>
               <li>Contact information for further questions or concerns</li>
             </ul>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>
             <h2>9. Dispute Resolution and Arbitration</h2>
+          </CardHeader>
+          <CardBody>
             <h3>9.1. Informal Resolution</h3>
             <p>
               Before initiating any arbitration or court proceeding, you agree to first contact us at cardsclarity@gmail.com and attempt to resolve any dispute informally.
@@ -180,7 +228,13 @@ const PrivacyPolicy = () => {
             <p>
               You have the right to opt-out and not be bound by the arbitration and class action waiver provisions by sending written notice of your decision to opt-out to cardsclarity@gmail.com within 30 days of your first use of the Platform.
             </p>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>
             <h2>10. Termination</h2>
+          </CardHeader>
+          <CardBody>
             <h3>10.1. Termination by CardsClarity</h3>
             <p>
               We may terminate or suspend your account and bar access to the Platform immediately, without prior notice or liability, under our sole discretion, for any reason whatsoever and without limitation, including but not limited to a breach of this Agreement.
@@ -197,11 +251,23 @@ const PrivacyPolicy = () => {
             <p>
               All provisions of this Agreement which by their nature should survive termination shall survive termination, including, without limitation, ownership provisions, warranty disclaimers, indemnity and limitations of liability.
             </p>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>
             <h2>11. Changes to this Agreement</h2>
+          </CardHeader>
+          <CardBody>
             <p>
               We reserve the right to modify this Agreement at any time. We will notify users of any material changes by posting the new Agreement on the Platform and updating the "Last Updated" date at the top of this Agreement. Your continued use of the Platform after any such changes constitutes your acceptance of the new Agreement.
             </p>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardHeader>
             <h2>12. Contact Information</h2>
+          </CardHeader>
+          <CardBody>
             <p>
               If you have any questions about this Agreement, please contact us at:
             </p>

--- a/src/pages/privacyPolicy.js
+++ b/src/pages/privacyPolicy.js
@@ -1,13 +1,13 @@
 import React from "react";
 import TopNavbar from "../components/navbar/activeNavbar";
-import Footer from "../sections/Footer";
+import Footer from "../components/footer/footer";
 import { Card, CardHeader, CardBody, CardFooter } from "@nextui-org/react";
 
 const PrivacyPolicy = () => {
   return (
     <div>
       <TopNavbar />
-      <div className="container mx-auto p-4">
+      <div className="container mx-auto p-4 space-y-4">
         <Card>
           <CardHeader>
             <h1>Privacy Policy</h1>
@@ -16,7 +16,11 @@ const PrivacyPolicy = () => {
             <p>Last Updated: 08/20/2024</p>
             <h2>1. Introduction</h2>
             <p>
-              CardsClarity, Inc. ("CardsClarity," "we," "us," or "our") operates the website located at cardsclarity.com and related services (collectively, the "Platform"). This Terms of Service and Privacy Policy ("Agreement") governs your access to and use of the Platform.
+              CardsClarity, Inc. ("CardsClarity," "we," "us," or "our") operates
+              the website located at cardsclarity.com and related services
+              (collectively, the "Platform"). This Terms of Service and Privacy
+              Policy ("Agreement") governs your access to and use of the
+              Platform.
             </p>
           </CardBody>
         </Card>
@@ -26,7 +30,9 @@ const PrivacyPolicy = () => {
           </CardHeader>
           <CardBody>
             <p>
-              By accessing or using the Platform, you ("User," "you," or "your") agree to be bound by this Agreement. If you do not agree to these terms, you must not access or use the Platform.
+              By accessing or using the Platform, you ("User," "you," or "your")
+              agree to be bound by this Agreement. If you do not agree to these
+              terms, you must not access or use the Platform.
             </p>
           </CardBody>
         </Card>
@@ -36,7 +42,14 @@ const PrivacyPolicy = () => {
           </CardHeader>
           <CardBody>
             <p>
-              You must be at least 13 years old to use the Platform. If you are under 18 years old, you must have parental consent to use the Platform. We do not knowingly collect or solicit personal information from anyone under 13 or knowingly allow such persons to register for the Platform. If we become aware that we have collected personal information from a child under 13 without verification of parental consent, we will take steps to remove that information from our servers.
+              You must be at least 13 years old to use the Platform. If you are
+              under 18 years old, you must have parental consent to use the
+              Platform. We do not knowingly collect or solicit personal
+              information from anyone under 13 or knowingly allow such persons
+              to register for the Platform. If we become aware that we have
+              collected personal information from a child under 13 without
+              verification of parental consent, we will take steps to remove
+              that information from our servers.
             </p>
           </CardBody>
         </Card>
@@ -47,33 +60,63 @@ const PrivacyPolicy = () => {
           <CardBody>
             <h3>4.1. User Content</h3>
             <p>
-              The Platform allows Users to submit, post, and share content related to credit card products, including reviews, comments, and ratings ("User Content").
+              The Platform allows Users to submit, post, and share content
+              related to credit card products, including reviews, comments, and
+              ratings ("User Content").
             </p>
             <h3>4.2. Ownership and License</h3>
             <p>
-              You retain all ownership rights to your User Content. However, by submitting User Content to the Platform, you grant CardsClarity a worldwide, non-exclusive, royalty-free, sublicensable, and transferable license to use, reproduce, distribute, prepare derivative works of, display, and perform the User Content in connection with the Platform and CardsClarity's business operations.
+              You retain all ownership rights to your User Content. However, by
+              submitting User Content to the Platform, you grant CardsClarity a
+              worldwide, non-exclusive, royalty-free, sublicensable, and
+              transferable license to use, reproduce, distribute, prepare
+              derivative works of, display, and perform the User Content in
+              connection with the Platform and CardsClarity's business
+              operations.
             </p>
             <h3>4.3. Representations and Warranties</h3>
             <p>
-              You represent and warrant that: (i) you own the User Content posted by you on or through the Platform or otherwise have the right to grant the license set forth in this section, and (ii) your User Content does not violate the privacy rights, publicity rights, copyrights, contract rights, intellectual property rights or any other rights of any person or entity.
+              You represent and warrant that: (i) you own the User Content
+              posted by you on or through the Platform or otherwise have the
+              right to grant the license set forth in this section, and (ii)
+              your User Content does not violate the privacy rights, publicity
+              rights, copyrights, contract rights, intellectual property rights
+              or any other rights of any person or entity.
             </p>
             <h3>4.4. Prohibited Content</h3>
-            <p>
-              You agree not to post User Content that:
-            </p>
+            <p>You agree not to post User Content that:</p>
             <ul>
-              <li>Is illegal, obscene, defamatory, threatening, intimidating, harassing, hateful, racially, or ethnically offensive, or instigates or encourages conduct that would be illegal or otherwise inappropriate.</li>
-              <li>Infringes any patent, trademark, trade secret, copyright, or other intellectual or proprietary right of any party.</li>
-              <li>Contains software viruses or any other computer code designed to interrupt, destroy, or limit the functionality of any computer software or hardware.</li>
-              <li>Impersonates any person or entity or otherwise misrepresents your affiliation with a person or entity.</li>
+              <li>
+                Is illegal, obscene, defamatory, threatening, intimidating,
+                harassing, hateful, racially, or ethnically offensive, or
+                instigates or encourages conduct that would be illegal or
+                otherwise inappropriate.
+              </li>
+              <li>
+                Infringes any patent, trademark, trade secret, copyright, or
+                other intellectual or proprietary right of any party.
+              </li>
+              <li>
+                Contains software viruses or any other computer code designed to
+                interrupt, destroy, or limit the functionality of any computer
+                software or hardware.
+              </li>
+              <li>
+                Impersonates any person or entity or otherwise misrepresents
+                your affiliation with a person or entity.
+              </li>
             </ul>
             <h3>4.5. Monitoring and Removal</h3>
             <p>
-              CardsClarity reserves the right, but is not obligated, to monitor, edit, or remove any User Content at our sole discretion, including content that we determine violates this Agreement or may be offensive, illegal, or violate the rights of any third party.
+              CardsClarity reserves the right, but is not obligated, to monitor,
+              edit, or remove any User Content at our sole discretion, including
+              content that we determine violates this Agreement or may be
+              offensive, illegal, or violate the rights of any third party.
             </p>
             <h3>4.6. Consequences of Posting Prohibited Content</h3>
             <p>
-              If you post prohibited content, CardsClarity may, at its sole discretion:
+              If you post prohibited content, CardsClarity may, at its sole
+              discretion:
             </p>
             <ul>
               <li>Remove the content</li>
@@ -91,15 +134,27 @@ const PrivacyPolicy = () => {
           <CardBody>
             <h3>5.1. CardsClarity's Intellectual Property</h3>
             <p>
-              The Platform and its original content (excluding User Content), features, and functionality are owned by CardsClarity and are protected by international copyright, trademark, patent, trade secret, and other intellectual property or proprietary rights laws.
+              The Platform and its original content (excluding User Content),
+              features, and functionality are owned by CardsClarity and are
+              protected by international copyright, trademark, patent, trade
+              secret, and other intellectual property or proprietary rights
+              laws.
             </p>
             <h3>5.2. User's Intellectual Property</h3>
             <p>
-              You retain all rights to any content you submit, post or display on or through the Platform. By submitting, posting or displaying content on or through the Platform, you grant us a worldwide, non-exclusive, royalty-free license to use, reproduce, adapt, publish, translate and distribute it in any and all media.
+              You retain all rights to any content you submit, post or display
+              on or through the Platform. By submitting, posting or displaying
+              content on or through the Platform, you grant us a worldwide,
+              non-exclusive, royalty-free license to use, reproduce, adapt,
+              publish, translate and distribute it in any and all media.
             </p>
             <h3>5.3. Copyright Infringement</h3>
             <p>
-              If you believe that any User Content violates your copyright, please contact us at cardsclarity@gmail.com with a detailed description of the alleged infringement. We will respond to notices of alleged copyright infringement that comply with applicable law and are properly provided to us.
+              If you believe that any User Content violates your copyright,
+              please contact us at cardsclarity@gmail.com with a detailed
+              description of the alleged infringement. We will respond to
+              notices of alleged copyright infringement that comply with
+              applicable law and are properly provided to us.
             </p>
           </CardBody>
         </Card>
@@ -110,34 +165,47 @@ const PrivacyPolicy = () => {
           <CardBody>
             <h3>6.1. Data Collection</h3>
             <p>
-              We collect personal information you provide during account creation and platform interaction, including email address, name, account password, username, comments, and votes.
+              We collect personal information you provide during account
+              creation and platform interaction, including email address, name,
+              account password, username, comments, and votes.
             </p>
             <h3>6.2. Data Usage</h3>
             <p>
-              We use collected information to manage accounts, facilitate communication, personalize content, and improve our services.
+              We use collected information to manage accounts, facilitate
+              communication, personalize content, and improve our services.
             </p>
             <h3>6.3. Data Security</h3>
             <p>
-              We implement industry-standard encryption protocols and security measures to protect user data from unauthorized access and potential breaches. These measures include:
+              We implement industry-standard encryption protocols and security
+              measures to protect user data from unauthorized access and
+              potential breaches. These measures include:
             </p>
             <ul>
               <li>Secure Socket Layer (SSL) technology</li>
               <li>Regular security audits</li>
               <li>Employee training on data protection</li>
-              <li>Limited access to personal information on a need-to-know basis</li>
+              <li>
+                Limited access to personal information on a need-to-know basis
+              </li>
               <li>Firewalls and intrusion detection systems</li>
             </ul>
             <h3>6.4. Data Aggregation</h3>
             <p>
-              Credit card-related information displayed on the Platform is collected through secure API calls and web scraping techniques from official sources. CardsClarity does not independently verify this information and makes no representations or warranties regarding its accuracy.
+              Credit card-related information displayed on the Platform is
+              collected through secure API calls and web scraping techniques
+              from official sources. CardsClarity does not independently verify
+              this information and makes no representations or warranties
+              regarding its accuracy.
             </p>
             <h3>6.5. Cookies</h3>
             <p>
-              We use cookies strictly for authorization purposes. No other data is collected or used from cookies.
+              We use cookies strictly for authorization purposes. No other data
+              is collected or used from cookies.
             </p>
             <h3>6.6. Third-Party Services</h3>
             <p>
-              We use the following third-party services for data processing and analytics:
+              We use the following third-party services for data processing and
+              analytics:
             </p>
             <ul>
               <li>Google Analytics for website traffic analysis</li>
@@ -145,15 +213,22 @@ const PrivacyPolicy = () => {
               <li>SendGrid for email communications</li>
             </ul>
             <p>
-              These services may collect and process personal information as per their own privacy policies.
+              These services may collect and process personal information as per
+              their own privacy policies.
             </p>
             <h3>6.7. Data Retention</h3>
             <p>
-              We retain user data for as long as an account is active or as needed to provide services. If you delete your account, we will delete your personal information within 30 days, except for information we are required to retain for legal or business purposes.
+              We retain user data for as long as an account is active or as
+              needed to provide services. If you delete your account, we will
+              delete your personal information within 30 days, except for
+              information we are required to retain for legal or business
+              purposes.
             </p>
             <h3>6.8. Updates to Privacy Policy</h3>
             <p>
-              We will notify users of any material changes to this Privacy Policy via email and/or a prominent notice on our Platform at least 30 days prior to the changes becoming effective.
+              We will notify users of any material changes to this Privacy
+              Policy via email and/or a prominent notice on our Platform at
+              least 30 days prior to the changes becoming effective.
             </p>
           </CardBody>
         </Card>
@@ -163,26 +238,36 @@ const PrivacyPolicy = () => {
           </CardHeader>
           <CardBody>
             <p>
-              For California residents, in addition to the rights described elsewhere in this Agreement, you have the following rights under the CCPA:
+              For California residents, in addition to the rights described
+              elsewhere in this Agreement, you have the following rights under
+              the CCPA:
             </p>
             <h3>7.1. Right to Know</h3>
             <p>
-              You have the right to request that we disclose certain information to you about our collection and use of your personal information over the past 12 months.
+              You have the right to request that we disclose certain information
+              to you about our collection and use of your personal information
+              over the past 12 months.
             </p>
             <h3>7.2. Right to Delete</h3>
             <p>
-              You have the right to request that we delete any of your personal information that we collected from you and retained, subject to certain exceptions.
+              You have the right to request that we delete any of your personal
+              information that we collected from you and retained, subject to
+              certain exceptions.
             </p>
             <h3>7.3. Right to Opt-Out of Sale</h3>
             <p>
-              We do not sell personal information. However, if we did, you would have the right to opt-out of the sale of your personal information.
+              We do not sell personal information. However, if we did, you would
+              have the right to opt-out of the sale of your personal
+              information.
             </p>
             <h3>7.4. Right to Non-Discrimination</h3>
             <p>
-              We will not discriminate against you for exercising any of your CCPA rights.
+              We will not discriminate against you for exercising any of your
+              CCPA rights.
             </p>
             <p>
-              To exercise these rights, please contact us at cardsclarity@gmail.com.
+              To exercise these rights, please contact us at
+              cardsclarity@gmail.com.
             </p>
           </CardBody>
         </Card>
@@ -192,12 +277,16 @@ const PrivacyPolicy = () => {
           </CardHeader>
           <CardBody>
             <p>
-              In the event of a data breach that compromises your personal information, we will notify you via email within 72 hours of discovering the breach. The notification will include:
+              In the event of a data breach that compromises your personal
+              information, we will notify you via email within 72 hours of
+              discovering the breach. The notification will include:
             </p>
             <ul>
               <li>A description of the nature of the breach</li>
               <li>The types of information potentially involved</li>
-              <li>Steps we are taking to investigate and mitigate the breach</li>
+              <li>
+                Steps we are taking to investigate and mitigate the breach
+              </li>
               <li>Recommended steps you can take to protect yourself</li>
               <li>Contact information for further questions or concerns</li>
             </ul>
@@ -210,23 +299,45 @@ const PrivacyPolicy = () => {
           <CardBody>
             <h3>9.1. Informal Resolution</h3>
             <p>
-              Before initiating any arbitration or court proceeding, you agree to first contact us at cardsclarity@gmail.com and attempt to resolve any dispute informally.
+              Before initiating any arbitration or court proceeding, you agree
+              to first contact us at cardsclarity@gmail.com and attempt to
+              resolve any dispute informally.
             </p>
             <h3>9.2. Arbitration Agreement</h3>
             <p>
-              If informal resolution is unsuccessful, any dispute, controversy, or claim arising out of or relating to this Agreement, or the breach thereof, shall be determined by arbitration administered by the American Arbitration Association in accordance with its Commercial Arbitration Rules.
+              If informal resolution is unsuccessful, any dispute, controversy,
+              or claim arising out of or relating to this Agreement, or the
+              breach thereof, shall be determined by arbitration administered by
+              the American Arbitration Association in accordance with its
+              Commercial Arbitration Rules.
             </p>
             <h3>9.3. Arbitration Process</h3>
             <p>
-              The arbitration will be conducted in the English language in United States, New York. One arbitrator will be selected in accordance with the American Arbitration Association Rules. Each party will be responsible for paying any filing, administrative, and arbitrator fees in accordance with American Arbitration Association Rules.
+              The arbitration will be conducted in the English language in
+              United States, New York. One arbitrator will be selected in
+              accordance with the American Arbitration Association Rules. Each
+              party will be responsible for paying any filing, administrative,
+              and arbitrator fees in accordance with American Arbitration
+              Association Rules.
             </p>
             <h3>9.4. Class Action Waiver</h3>
             <p>
-              You agree that any arbitration or proceeding shall be limited to the dispute between us and you individually. To the fullest extent permitted by law, (i) no arbitration or proceeding shall be joined with any other; (ii) there is no right or authority for any dispute to be arbitrated or resolved on a class action basis or to utilize class action procedures; and (iii) there is no right or authority for any dispute to be brought in a purported representative capacity on behalf of the general public or any other persons.
+              You agree that any arbitration or proceeding shall be limited to
+              the dispute between us and you individually. To the fullest extent
+              permitted by law, (i) no arbitration or proceeding shall be joined
+              with any other; (ii) there is no right or authority for any
+              dispute to be arbitrated or resolved on a class action basis or to
+              utilize class action procedures; and (iii) there is no right or
+              authority for any dispute to be brought in a purported
+              representative capacity on behalf of the general public or any
+              other persons.
             </p>
             <h3>9.5. Opt-Out</h3>
             <p>
-              You have the right to opt-out and not be bound by the arbitration and class action waiver provisions by sending written notice of your decision to opt-out to cardsclarity@gmail.com within 30 days of your first use of the Platform.
+              You have the right to opt-out and not be bound by the arbitration
+              and class action waiver provisions by sending written notice of
+              your decision to opt-out to cardsclarity@gmail.com within 30 days
+              of your first use of the Platform.
             </p>
           </CardBody>
         </Card>
@@ -237,19 +348,28 @@ const PrivacyPolicy = () => {
           <CardBody>
             <h3>10.1. Termination by CardsClarity</h3>
             <p>
-              We may terminate or suspend your account and bar access to the Platform immediately, without prior notice or liability, under our sole discretion, for any reason whatsoever and without limitation, including but not limited to a breach of this Agreement.
+              We may terminate or suspend your account and bar access to the
+              Platform immediately, without prior notice or liability, under our
+              sole discretion, for any reason whatsoever and without limitation,
+              including but not limited to a breach of this Agreement.
             </p>
             <h3>10.2. Termination by User</h3>
             <p>
-              You may terminate your account at any time by contacting us at cardsclarity@gmail.com.
+              You may terminate your account at any time by contacting us at
+              cardsclarity@gmail.com.
             </p>
             <h3>10.3. Effect of Termination</h3>
             <p>
-              Upon termination, your right to use the Platform will immediately cease. If you wish to terminate your account, you may simply discontinue using the Platform.
+              Upon termination, your right to use the Platform will immediately
+              cease. If you wish to terminate your account, you may simply
+              discontinue using the Platform.
             </p>
             <h3>10.4. Survival of Terms</h3>
             <p>
-              All provisions of this Agreement which by their nature should survive termination shall survive termination, including, without limitation, ownership provisions, warranty disclaimers, indemnity and limitations of liability.
+              All provisions of this Agreement which by their nature should
+              survive termination shall survive termination, including, without
+              limitation, ownership provisions, warranty disclaimers, indemnity
+              and limitations of liability.
             </p>
           </CardBody>
         </Card>
@@ -259,7 +379,11 @@ const PrivacyPolicy = () => {
           </CardHeader>
           <CardBody>
             <p>
-              We reserve the right to modify this Agreement at any time. We will notify users of any material changes by posting the new Agreement on the Platform and updating the "Last Updated" date at the top of this Agreement. Your continued use of the Platform after any such changes constitutes your acceptance of the new Agreement.
+              We reserve the right to modify this Agreement at any time. We will
+              notify users of any material changes by posting the new Agreement
+              on the Platform and updating the "Last Updated" date at the top of
+              this Agreement. Your continued use of the Platform after any such
+              changes constitutes your acceptance of the new Agreement.
             </p>
           </CardBody>
         </Card>
@@ -269,22 +393,16 @@ const PrivacyPolicy = () => {
           </CardHeader>
           <CardBody>
             <p>
-              If you have any questions about this Agreement, please contact us at:
+              If you have any questions about this Agreement, please contact us
+              at:
             </p>
+            <p>CardsClarity, Inc.</p>
+            <p>Email: cardsclarity@gmail.com</p>
+            <p>Phone: +1 (650) 4540709 - Dylan Bardsley (CEO)</p>
+            <p>Phone: +1 (347) 4706644 - Mark Leaf (CTO)</p>
             <p>
-              CardsClarity, Inc.
-            </p>
-            <p>
-              Email: cardsclarity@gmail.com
-            </p>
-            <p>
-              Phone: +1 (650) 4540709 - Dylan Bardsley (CEO)
-            </p>
-            <p>
-              Phone: +1 (347) 4706644 - Mark Leaf (CTO)
-            </p>
-            <p>
-              By using the CardsClarity Platform, you acknowledge that you have read, understood, and agree to be bound by this Agreement.
+              By using the CardsClarity Platform, you acknowledge that you have
+              read, understood, and agree to be bound by this Agreement.
             </p>
           </CardBody>
           <CardFooter>

--- a/src/pages/privacyPolicy.js
+++ b/src/pages/privacyPolicy.js
@@ -1,0 +1,218 @@
+import React from "react";
+
+const PrivacyPolicy = () => {
+  return (
+    <div className="privacy-policy">
+      <h1>Privacy Policy</h1>
+      <p>Last Updated: 08/20/2024</p>
+      <h2>1. Introduction</h2>
+      <p>
+        CardsClarity, Inc. ("CardsClarity," "we," "us," or "our") operates the website located at cardsclarity.com and related services (collectively, the "Platform"). This Terms of Service and Privacy Policy ("Agreement") governs your access to and use of the Platform.
+      </p>
+      <h2>2. Acceptance of Terms</h2>
+      <p>
+        By accessing or using the Platform, you ("User," "you," or "your") agree to be bound by this Agreement. If you do not agree to these terms, you must not access or use the Platform.
+      </p>
+      <h2>3. Age Restrictions</h2>
+      <p>
+        You must be at least 13 years old to use the Platform. If you are under 18 years old, you must have parental consent to use the Platform. We do not knowingly collect or solicit personal information from anyone under 13 or knowingly allow such persons to register for the Platform. If we become aware that we have collected personal information from a child under 13 without verification of parental consent, we will take steps to remove that information from our servers.
+      </p>
+      <h2>4. User-Generated Content</h2>
+      <h3>4.1. User Content</h3>
+      <p>
+        The Platform allows Users to submit, post, and share content related to credit card products, including reviews, comments, and ratings ("User Content").
+      </p>
+      <h3>4.2. Ownership and License</h3>
+      <p>
+        You retain all ownership rights to your User Content. However, by submitting User Content to the Platform, you grant CardsClarity a worldwide, non-exclusive, royalty-free, sublicensable, and transferable license to use, reproduce, distribute, prepare derivative works of, display, and perform the User Content in connection with the Platform and CardsClarity's business operations.
+      </p>
+      <h3>4.3. Representations and Warranties</h3>
+      <p>
+        You represent and warrant that: (i) you own the User Content posted by you on or through the Platform or otherwise have the right to grant the license set forth in this section, and (ii) your User Content does not violate the privacy rights, publicity rights, copyrights, contract rights, intellectual property rights or any other rights of any person or entity.
+      </p>
+      <h3>4.4. Prohibited Content</h3>
+      <p>
+        You agree not to post User Content that:
+      </p>
+      <ul>
+        <li>Is illegal, obscene, defamatory, threatening, intimidating, harassing, hateful, racially, or ethnically offensive, or instigates or encourages conduct that would be illegal or otherwise inappropriate.</li>
+        <li>Infringes any patent, trademark, trade secret, copyright, or other intellectual or proprietary right of any party.</li>
+        <li>Contains software viruses or any other computer code designed to interrupt, destroy, or limit the functionality of any computer software or hardware.</li>
+        <li>Impersonates any person or entity or otherwise misrepresents your affiliation with a person or entity.</li>
+      </ul>
+      <h3>4.5. Monitoring and Removal</h3>
+      <p>
+        CardsClarity reserves the right, but is not obligated, to monitor, edit, or remove any User Content at our sole discretion, including content that we determine violates this Agreement or may be offensive, illegal, or violate the rights of any third party.
+      </p>
+      <h3>4.6. Consequences of Posting Prohibited Content</h3>
+      <p>
+        If you post prohibited content, CardsClarity may, at its sole discretion:
+      </p>
+      <ul>
+        <li>Remove the content</li>
+        <li>Issue a warning</li>
+        <li>Temporarily or permanently suspend your account</li>
+        <li>Ban you from the Platform</li>
+        <li>Take legal action if necessary</li>
+      </ul>
+      <h2>5. Intellectual Property Rights</h2>
+      <h3>5.1. CardsClarity's Intellectual Property</h3>
+      <p>
+        The Platform and its original content (excluding User Content), features, and functionality are owned by CardsClarity and are protected by international copyright, trademark, patent, trade secret, and other intellectual property or proprietary rights laws.
+      </p>
+      <h3>5.2. User's Intellectual Property</h3>
+      <p>
+        You retain all rights to any content you submit, post or display on or through the Platform. By submitting, posting or displaying content on or through the Platform, you grant us a worldwide, non-exclusive, royalty-free license to use, reproduce, adapt, publish, translate and distribute it in any and all media.
+      </p>
+      <h3>5.3. Copyright Infringement</h3>
+      <p>
+        If you believe that any User Content violates your copyright, please contact us at cardsclarity@gmail.com with a detailed description of the alleged infringement. We will respond to notices of alleged copyright infringement that comply with applicable law and are properly provided to us.
+      </p>
+      <h2>6. Privacy Policy</h2>
+      <h3>6.1. Data Collection</h3>
+      <p>
+        We collect personal information you provide during account creation and platform interaction, including email address, name, account password, username, comments, and votes.
+      </p>
+      <h3>6.2. Data Usage</h3>
+      <p>
+        We use collected information to manage accounts, facilitate communication, personalize content, and improve our services.
+      </p>
+      <h3>6.3. Data Security</h3>
+      <p>
+        We implement industry-standard encryption protocols and security measures to protect user data from unauthorized access and potential breaches. These measures include:
+      </p>
+      <ul>
+        <li>Secure Socket Layer (SSL) technology</li>
+        <li>Regular security audits</li>
+        <li>Employee training on data protection</li>
+        <li>Limited access to personal information on a need-to-know basis</li>
+        <li>Firewalls and intrusion detection systems</li>
+      </ul>
+      <h3>6.4. Data Aggregation</h3>
+      <p>
+        Credit card-related information displayed on the Platform is collected through secure API calls and web scraping techniques from official sources. CardsClarity does not independently verify this information and makes no representations or warranties regarding its accuracy.
+      </p>
+      <h3>6.5. Cookies</h3>
+      <p>
+        We use cookies strictly for authorization purposes. No other data is collected or used from cookies.
+      </p>
+      <h3>6.6. Third-Party Services</h3>
+      <p>
+        We use the following third-party services for data processing and analytics:
+      </p>
+      <ul>
+        <li>Google Analytics for website traffic analysis</li>
+        <li>Stripe for payment processing</li>
+        <li>SendGrid for email communications</li>
+      </ul>
+      <p>
+        These services may collect and process personal information as per their own privacy policies.
+      </p>
+      <h3>6.7. Data Retention</h3>
+      <p>
+        We retain user data for as long as an account is active or as needed to provide services. If you delete your account, we will delete your personal information within 30 days, except for information we are required to retain for legal or business purposes.
+      </p>
+      <h3>6.8. Updates to Privacy Policy</h3>
+      <p>
+        We will notify users of any material changes to this Privacy Policy via email and/or a prominent notice on our Platform at least 30 days prior to the changes becoming effective.
+      </p>
+      <h2>7. California Consumer Privacy Act (CCPA) Rights</h2>
+      <p>
+        For California residents, in addition to the rights described elsewhere in this Agreement, you have the following rights under the CCPA:
+      </p>
+      <h3>7.1. Right to Know</h3>
+      <p>
+        You have the right to request that we disclose certain information to you about our collection and use of your personal information over the past 12 months.
+      </p>
+      <h3>7.2. Right to Delete</h3>
+      <p>
+        You have the right to request that we delete any of your personal information that we collected from you and retained, subject to certain exceptions.
+      </p>
+      <h3>7.3. Right to Opt-Out of Sale</h3>
+      <p>
+        We do not sell personal information. However, if we did, you would have the right to opt-out of the sale of your personal information.
+      </p>
+      <h3>7.4. Right to Non-Discrimination</h3>
+      <p>
+        We will not discriminate against you for exercising any of your CCPA rights.
+      </p>
+      <p>
+        To exercise these rights, please contact us at cardsclarity@gmail.com.
+      </p>
+      <h2>8. Data Breach Notification</h2>
+      <p>
+        In the event of a data breach that compromises your personal information, we will notify you via email within 72 hours of discovering the breach. The notification will include:
+      </p>
+      <ul>
+        <li>A description of the nature of the breach</li>
+        <li>The types of information potentially involved</li>
+        <li>Steps we are taking to investigate and mitigate the breach</li>
+        <li>Recommended steps you can take to protect yourself</li>
+        <li>Contact information for further questions or concerns</li>
+      </ul>
+      <h2>9. Dispute Resolution and Arbitration</h2>
+      <h3>9.1. Informal Resolution</h3>
+      <p>
+        Before initiating any arbitration or court proceeding, you agree to first contact us at cardsclarity@gmail.com and attempt to resolve any dispute informally.
+      </p>
+      <h3>9.2. Arbitration Agreement</h3>
+      <p>
+        If informal resolution is unsuccessful, any dispute, controversy, or claim arising out of or relating to this Agreement, or the breach thereof, shall be determined by arbitration administered by the American Arbitration Association in accordance with its Commercial Arbitration Rules.
+      </p>
+      <h3>9.3. Arbitration Process</h3>
+      <p>
+        The arbitration will be conducted in the English language in United States, New York. One arbitrator will be selected in accordance with the American Arbitration Association Rules. Each party will be responsible for paying any filing, administrative, and arbitrator fees in accordance with American Arbitration Association Rules.
+      </p>
+      <h3>9.4. Class Action Waiver</h3>
+      <p>
+        You agree that any arbitration or proceeding shall be limited to the dispute between us and you individually. To the fullest extent permitted by law, (i) no arbitration or proceeding shall be joined with any other; (ii) there is no right or authority for any dispute to be arbitrated or resolved on a class action basis or to utilize class action procedures; and (iii) there is no right or authority for any dispute to be brought in a purported representative capacity on behalf of the general public or any other persons.
+      </p>
+      <h3>9.5. Opt-Out</h3>
+      <p>
+        You have the right to opt-out and not be bound by the arbitration and class action waiver provisions by sending written notice of your decision to opt-out to cardsclarity@gmail.com within 30 days of your first use of the Platform.
+      </p>
+      <h2>10. Termination</h2>
+      <h3>10.1. Termination by CardsClarity</h3>
+      <p>
+        We may terminate or suspend your account and bar access to the Platform immediately, without prior notice or liability, under our sole discretion, for any reason whatsoever and without limitation, including but not limited to a breach of this Agreement.
+      </p>
+      <h3>10.2. Termination by User</h3>
+      <p>
+        You may terminate your account at any time by contacting us at cardsclarity@gmail.com.
+      </p>
+      <h3>10.3. Effect of Termination</h3>
+      <p>
+        Upon termination, your right to use the Platform will immediately cease. If you wish to terminate your account, you may simply discontinue using the Platform.
+      </p>
+      <h3>10.4. Survival of Terms</h3>
+      <p>
+        All provisions of this Agreement which by their nature should survive termination shall survive termination, including, without limitation, ownership provisions, warranty disclaimers, indemnity and limitations of liability.
+      </p>
+      <h2>11. Changes to this Agreement</h2>
+      <p>
+        We reserve the right to modify this Agreement at any time. We will notify users of any material changes by posting the new Agreement on the Platform and updating the "Last Updated" date at the top of this Agreement. Your continued use of the Platform after any such changes constitutes your acceptance of the new Agreement.
+      </p>
+      <h2>12. Contact Information</h2>
+      <p>
+        If you have any questions about this Agreement, please contact us at:
+      </p>
+      <p>
+        CardsClarity, Inc.
+      </p>
+      <p>
+        Email: cardsclarity@gmail.com
+      </p>
+      <p>
+        Phone: +1 (650) 4540709 - Dylan Bardsley (CEO)
+      </p>
+      <p>
+        Phone: +1 (347) 4706644 - Mark Leaf (CTO)
+      </p>
+      <p>
+        By using the CardsClarity Platform, you acknowledge that you have read, understood, and agree to be bound by this Agreement.
+      </p>
+    </div>
+  );
+};
+
+export default PrivacyPolicy;

--- a/src/sections/Footer.js
+++ b/src/sections/Footer.js
@@ -22,11 +22,11 @@ export default function Footer() {
         </div>
         <div className="flex flex-col md:flex-row justify-between items-center mt-4">
           <div className="flex space-x-4 text-sm text-gray-600">
-            <a className="hover:text-gray-800" href="#">
+            <a className="hover:text-gray-800" href="/legal-stuff">
               Legal Stuff
             </a>
             <span>|</span>
-            <a className="hover:text-gray-800" href="#">
+            <a className="hover:text-gray-800" href="/privacy-policy">
               Privacy Policy
             </a>
             <span>|</span>


### PR DESCRIPTION
Add "Legal Stuff" and "Privacy Policy" pages and make them accessible from direct links and the footer.

* **src/App.js**
  - Add routes for "Legal Stuff" and "Privacy Policy" pages.
* **src/components/footer/footer.js**
  - Update links for "Legal Stuff" and "Privacy Policy" to be functional.
* **src/pages/legalStuff.js**
  - Create "Legal Stuff" page with the provided content.
* **src/pages/privacyPolicy.js**
  - Create "Privacy Policy" page with the provided content.
* **src/sections/Footer.js**
  - Update links for "Legal Stuff" and "Privacy Policy" to be functional.

