### PR TITLE
Fix 'Enter' key search functionality in search bar

### DIFF
--- a/src/pages/searchForCard.js
+++ b/src/pages/searchForCard.js
@@ -90,7 +90,7 @@ function ReviewSearch() {
   };
 
   const handleKeyPress = (event) => {
-    if (event.key === 'Enter' && searchResults.length > 0) {
+    if (event.key === "Enter" && searchResults.length > 0) {
       handleClickSearchResult(searchResults[0]._id);
     }
   };
@@ -188,7 +188,7 @@ function ReviewSearch() {
                       "h-[56px] sm:h-[64px] bg-white dark:bg-gray-900",
                   },
                   onClick: handleInputClick,
-                  onKeyPress: handleKeyPress,
+                  onKeyDown: handleKeyPress,
                 }}
                 listboxProps={{
                   emptyContent:

--- a/src/pages/searchForCard.js
+++ b/src/pages/searchForCard.js
@@ -89,6 +89,12 @@ function ReviewSearch() {
     }
   };
 
+  const handleKeyPress = (event) => {
+    if (event.key === 'Enter' && searchResults.length > 0) {
+      handleClickSearchResult(searchResults[0]._id);
+    }
+  };
+
   const handleInputClick = useCallback(() => {
     if (inputRef.current) {
       inputRef.current.focus();
@@ -182,6 +188,7 @@ function ReviewSearch() {
                       "h-[56px] sm:h-[64px] bg-white dark:bg-gray-900",
                   },
                   onClick: handleInputClick,
+                  onKeyPress: handleKeyPress,
                 }}
                 listboxProps={{
                   emptyContent:


### PR DESCRIPTION
Add 'Enter' key handling to search bar to navigate to best matching card.

* Add `handleKeyPress` function to handle 'Enter' key presses and navigate to the best matching card.
* Update `Autocomplete` component's `inputProps` to include `onKeyPress` event handler that calls `handleKeyPress` function.
* Use `handleClickSearchResult` function to navigate to the best matching card when 'Enter' key is pressed.

