### PR TITLE
Fix ResizeObserver error in CardDetails component

### DIFF
--- a/src/components/CARDPAGE/CardDetails.js
+++ b/src/components/CARDPAGE/CardDetails.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { Tabs, Tab } from "@nextui-org/react";
 import Reviews from "./Reviews";
 import Cashback from "./Cashback";
@@ -11,40 +11,64 @@ const CardDetails = ({
   cardData,
   averageRating,
   reviews,
-}) => (
-  <div className="flex flex-col">
-    <Tabs
-      size="lg"
-      disableAnimation
-      disableCursorAnimation
-      aria-label="Card benefits"
-      className="w-full transform-gpu mx-auto justify-center"
-      selectedKey={selectedTab}
-      onSelectionChange={handleTabChange}
-    >
-      <Tab key="reviews" title="Reviews" />
-      <Tab key="cashback" title="Cashback" />
-      <Tab key="perks" title="Perks" />
-      <Tab key="more" title="More" />
-    </Tabs>
+}) => {
+  const containerRef = useRef(null);
+  const resizeObserverRef = useRef(null);
 
-    <div className="mt-4">
-      {selectedTab === "reviews" && (
-        <Reviews reviews={reviews} cardName={cardData.cardName} />
-      )}
+  useEffect(() => {
+    const handleResize = (entries) => {
+      for (let entry of entries) {
+        console.log("Resized:", entry.target);
+      }
+    };
 
-      {selectedTab === "cashback" && (
-        <Cashback cashbackPercentages={cardData.cashbackPercentages} />
-      )}
-      {selectedTab === "perks" && (
-        <Perks
-          perks={cardData.perks}
-          redemptionOptions={cardData.redemptionOptions}
-        />
-      )}
-      {selectedTab === "more" && <More cardData={cardData} />}
+    resizeObserverRef.current = new ResizeObserver(handleResize);
+    if (containerRef.current) {
+      resizeObserverRef.current.observe(containerRef.current);
+    }
+
+    return () => {
+      if (resizeObserverRef.current) {
+        resizeObserverRef.current.disconnect();
+      }
+    };
+  }, []);
+
+  return (
+    <div className="flex flex-col" ref={containerRef}>
+      <Tabs
+        size="lg"
+        disableAnimation
+        disableCursorAnimation
+        aria-label="Card benefits"
+        className="w-full transform-gpu mx-auto justify-center"
+        selectedKey={selectedTab}
+        onSelectionChange={handleTabChange}
+      >
+        <Tab key="reviews" title="Reviews" />
+        <Tab key="cashback" title="Cashback" />
+        <Tab key="perks" title="Perks" />
+        <Tab key="more" title="More" />
+      </Tabs>
+
+      <div className="mt-4">
+        {selectedTab === "reviews" && (
+          <Reviews reviews={reviews} cardName={cardData.cardName} />
+        )}
+
+        {selectedTab === "cashback" && (
+          <Cashback cashbackPercentages={cardData.cashbackPercentages} />
+        )}
+        {selectedTab === "perks" && (
+          <Perks
+            perks={cardData.perks}
+            redemptionOptions={cardData.redemptionOptions}
+          />
+        )}
+        {selectedTab === "more" && <More cardData={cardData} />}
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default React.memo(CardDetails);


### PR DESCRIPTION
Add a `ResizeObserver` to the `CardDetails` component to observe changes in the size of the card details container and manage it properly.

* **ResizeObserver Implementation**
  - Import `useEffect` and `useRef` from React.
  - Add a `containerRef` to reference the card details container.
  - Add a `resizeObserverRef` to reference the `ResizeObserver`.
  - Create a `handleResize` function to log resized elements.
  - Initialize and observe the `ResizeObserver` in a `useEffect` hook.
  - Disconnect the `ResizeObserver` when the component is unmounted.

* **Component Structure**
  - Wrap the card details container with a `div` and assign `containerRef` to it.
  - Maintain the existing structure of the `Tabs` and card details content.

