### PR TITLE
Fix centering of registration modal on mobile

### DIFF
--- a/src/components/ui/signing/SignUpModal.js
+++ b/src/components/ui/signing/SignUpModal.js
@@ -400,7 +400,13 @@ export default function SignUpModal({ isOpen, onClose }) {
   return (
     <>
       <LazyMotion features={domAnimation}>
-        <Modal isOpen={isOpen} onClose={onClose} size="lg">
+        <Modal
+          isOpen={isOpen}
+          onClose={onClose}
+          size="lg"
+          fullScreen={false}
+          className="my-auto flex items-center justify-center"
+        >
           <ModalContent>
             <ModalHeader className="flex flex-col gap-1">
               {isSignUp ? "Create an account" : "Welcome back"}


### PR DESCRIPTION
Center the registration/sign up modal on mobile devices.

* Add `my-auto` class to `Modal` component to center it vertically on mobile.
* Set `fullScreen` prop of `Modal` component to `false` to prevent full screen on mobile.
* Add `flex items-center justify-center` classes to `Modal` component to ensure proper centering.

